### PR TITLE
fix(ci): scope analyze to app code, skip broken sub-packages

### DIFF
--- a/.dart_analyze_skip
+++ b/.dart_analyze_skip
@@ -2,3 +2,4 @@
 # These have pre-existing issues tracked separately.
 soliplex_agent
 soliplex_cli
+soliplex_interpreter_monty

--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -44,7 +44,7 @@ jobs:
             -print0 | xargs -0 dart format --set-exit-if-changed
 
       - name: Analyze code
-        run: flutter analyze --fatal-infos
+        run: dart analyze --fatal-infos lib/ test/
 
       - name: Install DCM
         uses: CQLabs/setup-dcm@v2


### PR DESCRIPTION
## Summary
- CI `flutter analyze --fatal-infos` scans the entire workspace including `soliplex_cli` and `soliplex_interpreter_monty` which aren't in the root pubspec — their imports fail to resolve, breaking the lint job
- Change to `dart analyze --fatal-infos lib/ test/` matching the pre-commit hook
- Add `soliplex_interpreter_monty` to `.dart_analyze_skip`

## Changes
- **`.github/workflows/flutter.yaml`**: `flutter analyze --fatal-infos` → `dart analyze --fatal-infos lib/ test/`
- **`.dart_analyze_skip`**: Add `soliplex_interpreter_monty`

## Test plan
- [x] `dart analyze --fatal-infos lib/ test/` passes locally
- [x] All pre-commit hooks pass
- [x] CI lint job should now pass