### PR TITLE
docs(audit): fix top-level CLAUDE.md and docs/index.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,19 +20,23 @@ npx markdownlint-cli "<file>"            # Lint markdown after editing .md files
 lib/
   core/           # auth/, logging/, models/, providers/ (17), router/
   design/         # Color, theme, tokens (design system)
-  features/       # auth, chat, history, home, inspector, log_viewer,
+  features/       # auth, chat, debug, history, home, inspector, log_viewer,
                   # login, quiz, room, rooms, settings
   shared/         # Reusable widgets and utilities
 packages/
-  soliplex_client/        # Pure Dart: REST API, AG-UI, domain models
-  soliplex_client_native/ # Platform HTTP adapters (Cupertino)
-  soliplex_logging/       # Pure Dart: logging, DiskQueue, BackendLogSink
+  soliplex_agent/          # Pure Dart: agent orchestration (RunOrchestrator, AgentRuntime, AgentSession)
+  soliplex_cli/            # Interactive REPL for exercising soliplex_agent
+  soliplex_client/         # Pure Dart: REST API, AG-UI, domain models
+  soliplex_client_native/  # Platform HTTP adapters (Cupertino)
+  soliplex_interpreter_monty/ # Pure Dart: Monty Python sandbox bridge
+  soliplex_logging/        # Pure Dart: logging, DiskQueue, BackendLogSink
+  soliplex_scripting/      # Pure Dart: wiring ag-ui <-> interpreter bridge
 docs/                     # Documentation (see docs/index.md)
 ```
 
 ## Architecture
 
-Three layers: UI (features/) -> Core (providers, auth, logging) -> soliplex_client (pure Dart).
+Four layers: UI (features/) -> Core (providers, auth, logging) -> soliplex_agent (orchestration) -> soliplex_client (pure Dart). soliplex_scripting wires soliplex_agent to soliplex_interpreter_monty. soliplex_cli provides a terminal REPL over soliplex_agent.
 State management: Riverpod (manual providers, no codegen).
 Navigation: GoRouter. Logging: soliplex_logging via `Loggers.*` accessors.
 
@@ -43,7 +47,7 @@ Navigation: GoRouter. Logging: soliplex_logging via `Loggers.*` accessors.
 - Match surrounding code style exactly
 - Always refer to and abide by `docs/rules/flutter_rules.md`
 - Never use `// ignore:` directives - restructure code instead
-- Keep `soliplex_client` and `soliplex_logging` pure Dart (no Flutter imports)
+- Keep `soliplex_client`, `soliplex_logging`, `soliplex_agent`, `soliplex_scripting`, and `soliplex_interpreter_monty` pure Dart (no Flutter imports)
 - Platform-specific code goes in `soliplex_client_native`
 
 ## Code Quality
@@ -70,3 +74,4 @@ After any code modification, run in order:
 - [docs/logging-quickstart.md](docs/logging-quickstart.md) - Logging usage guide
 - [docs/guides/logging.md](docs/guides/logging.md) - Logging architecture
 - [docs/summary/client.md](docs/summary/client.md) - soliplex_client package
+- [docs/design/index.md](docs/design/index.md) - Design documents index

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,10 @@ The current frontend focuses on core chat functionality with essential features 
 ### Package Documentation
 
 - [Client Package](summary/client.md) - soliplex_client architecture and usage
+- [Agent Package](../packages/soliplex_agent/README.md) - soliplex_agent orchestration layer
+- [CLI Package](../packages/soliplex_cli/README.md) - Interactive REPL for soliplex_agent
+- [Scripting Package](../packages/soliplex_scripting/README.md) - AG-UI to interpreter bridge wiring
+- [Interpreter Monty Package](../packages/soliplex_interpreter_monty/README.md) - Monty Python sandbox bridge
 
 ---
 
@@ -43,29 +47,51 @@ The current frontend focuses on core chat functionality with essential features 
 
 ### Architecture
 
-The project follows a three-layer architecture:
+The project follows a four-layer architecture:
 
 ```mermaid
 flowchart TD
     A["UI Components<br/>(Chat, History, HttpInspector)"]
     B["Core Frontend<br/>Providers | Navigation | AG-UI Processing"]
-    C["soliplex_client<br/>(Pure Dart package)"]
+    C["soliplex_agent<br/>(Orchestration)"]
+    D["soliplex_client<br/>(Pure Dart package)"]
+    E["soliplex_scripting<br/>(AG-UI bridge wiring)"]
+    F["soliplex_interpreter_monty<br/>(Monty sandbox bridge)"]
+    G["soliplex_cli<br/>(Terminal REPL)"]
 
     A --> B
     B --> C
+    C --> D
+    E --> C
+    E --> F
+    G --> C
 
     style A fill:#e1f5ff
     style B fill:#fff4e1
-    style C fill:#e8f5e9
+    style C fill:#ffe4e1
+    style D fill:#e8f5e9
+    style E fill:#f3e5f5
+    style F fill:#f3e5f5
+    style G fill:#e0f7fa
 ```
 
 ### Packages
 
 | Package | Type | Status | Description |
 |---------|------|--------|-------------|
+| `soliplex_agent` | Pure Dart | Implemented | Agent orchestration (RunOrchestrator, AgentRuntime, AgentSession) |
+| `soliplex_cli` | Dart | Implemented | Interactive REPL for exercising soliplex_agent |
 | `soliplex_client` | Pure Dart | Implemented | HTTP/AG-UI client, models, sessions |
 | `soliplex_client_native` | Flutter | Implemented | Native HTTP adapters (iOS/macOS via Cupertino) |
+| `soliplex_interpreter_monty` | Pure Dart | Implemented | Monty Python sandbox bridge |
 | `soliplex_logging` | Pure Dart | Implemented | Logging primitives, DiskQueue, BackendLogSink |
+| `soliplex_scripting` | Pure Dart | Implemented | Wiring AG-UI to interpreter bridge |
+
+### Design & Planning
+
+- [Design Documents](design/index.md) - Architecture design documents and diagrams
+- [Planning Documents](planning/) - Implementation planning slices and references
+- [PLANS](../PLANS/) - Sprint plans, specs, and audit findings
 
 ### Implemented Features
 


### PR DESCRIPTION
## Summary
- Added 4 missing packages to project structure tree
- Updated architecture from "three layers" to "four layers"
- Added `debug` to features list
- Expanded pure Dart rule to cover all pure Dart packages
- Added link to docs/design/index.md

- Added 4 packages to packages table in docs/index.md
- Replaced 3-node mermaid diagram with 7-node four-layer diagram
- Added package documentation links for new packages
- Added Design & Planning section with links to docs/design/, docs/planning/, PLANS/

## Changes
- **CLAUDE.md**: Project structure, architecture desc, features list, pure Dart rule, docs section
- **docs/index.md**: Packages table, mermaid diagram, package docs links, design & planning section

## Test plan
- [x] `pymarkdown` scan passes
- [x] All pre-commit hooks pass