### PR TITLE
docs(audit): fix soliplex_interpreter_monty CLAUDE.md

### DIFF
--- a/packages/soliplex_interpreter_monty/CLAUDE.md
+++ b/packages/soliplex_interpreter_monty/CLAUDE.md
@@ -14,15 +14,37 @@ dart test --coverage
 
 ## Architecture
 
-- `MontyExecutionService` — core start/resume loop producing `Stream<ConsoleEvent>`
-- `PythonExecutorTool` — ClientTool factory (STUBBED until soliplex_client PRs merge)
-- `HostFunctionRegistry` — register and group HostFunctions
+### Bridge (core agentic pipeline)
+
+- `MontyBridge` — abstract bridge interface (`Stream<BridgeEvent> execute(code)`)
+- `DefaultMontyBridge` — Monty start/resume loop, host function dispatch, emits `Stream<BridgeEvent>`
+- `BridgeEvent` — sealed hierarchy (12 subtypes): protocol-agnostic lifecycle events
+
+### Host Functions
+
+- `HostFunction` — schema + async handler pair
+- `HostFunctionSchema` — name, description, params with `mapAndValidate()`
+- `HostFunctionRegistry` — groups HostFunctions by category, bulk-registers onto bridge
+- `HostParam` / `HostParamType` — parameter definitions with validation
+
+### Execution
+
+- `MontyExecutionService` — simple start/resume loop producing `Stream<ConsoleEvent>` (play button)
+- `ConsoleEvent` — sealed hierarchy: ConsoleOutput, ConsoleComplete, ConsoleError
+- `ExecutionResult` — return value + resource usage + collected output
+
+### Utilities
+
+- `SchemaExecutor` — Python-based schema validation via Monty
+- `InputVariable` / `InputVariableType` — form input variable definitions
+- `MontyLimitsDefaults` — preset resource limits (tool vs play-button)
 - `introspection_functions` — list_functions + help builtins
+- `ToolDefinitionConverter` / `ToolNameMapping` — backend tool def → bridge schema conversion
 
 ## Dependencies
 
 - `dart_monty_platform_interface` — MontyPlatform, MockMontyPlatform, all data types
-- `ag_ui` — Tool definition types
+- `meta` — @immutable annotations
 
 ## Rules
 

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/host_param.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/host_param.dart
@@ -21,7 +21,7 @@ class HostParam {
   /// Whether the caller must supply a value.
   final bool isRequired;
 
-  /// Human-readable description for ag-ui tool export.
+  /// Human-readable description for JSON Schema export.
   final String? description;
 
   /// Default value when the argument is absent and not required.

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/host_param_type.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/host_param_type.dart
@@ -18,7 +18,7 @@ enum HostParamType {
   /// Map/dict parameter. Monty Python `dict`.
   map;
 
-  /// JSON Schema type name for ag-ui Tool export.
+  /// JSON Schema type name for tool protocol export.
   String get jsonSchemaType => switch (this) {
         string => 'string',
         integer => 'integer',

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/tool_definition_converter.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/tool_definition_converter.dart
@@ -9,7 +9,7 @@ import 'package:soliplex_interpreter_monty/src/bridge/host_param_type.dart';
 ///
 /// - [pythonName]: The `kind` field — what Python calls
 ///   (e.g. `get_current_datetime`)
-/// - [registryName]: The `tool_name` field — what ag-ui uses
+/// - [registryName]: The `tool_name` field — the tool protocol lookup key
 ///   (e.g. `soliplex.tools.get_current_datetime`)
 /// - [schema]: The [HostFunctionSchema] registered with the bridge
 @immutable


### PR DESCRIPTION
## Summary
- Removed stale `ag_ui` dependency, added `meta` for @immutable annotations
- Replaced 4-item flat architecture list with complete 4-subsection breakdown
  (Bridge, Host Functions, Execution, Utilities)
- Updated 3 Dart code comments replacing "ag-ui" references with
  "JSON Schema export" / "tool protocol export"

## Changes
- **packages/soliplex_interpreter_monty/CLAUDE.md**: Dependencies, architecture
- **host_param.dart:24**: ag-ui → JSON Schema export
- **host_param_type.dart:21**: ag-ui → tool protocol export
- **tool_definition_converter.dart:12**: ag-ui → tool protocol lookup key

## Test plan
- [x] `dart analyze --fatal-infos` passes
- [x] `pymarkdown` scan passes
- [x] All pre-commit hooks pass