### PR TITLE
docs(audit): fix soliplex-agent-package.md stale API signatures

### DIFF
--- a/docs/design/monty-host-capabilities-integration.md
+++ b/docs/design/monty-host-capabilities-integration.md
@@ -190,10 +190,10 @@ for the full interface. Key flags consumed by the Monty layer:
 
 ### Where Platform Detection Happens
 
-The Flutter app provides the implementation at startup:
+The implementations live in `packages/soliplex_agent/lib/src/host/`:
 
 ```dart
-// In the Flutter app (not in soliplex_agent or soliplex_monty)
+// In packages/soliplex_agent/lib/src/host/native_platform_constraints.dart
 
 class NativePlatformConstraints implements PlatformConstraints {
   @override
@@ -201,7 +201,7 @@ class NativePlatformConstraints implements PlatformConstraints {
   @override
   bool get supportsAsyncMode => false; // Until MontyResolveFutures lands
   @override
-  int get maxConcurrentBridges => 256; // Practical limit
+  int get maxConcurrentBridges => 4; // Default for mobile
   @override
   bool get supportsReentrantInterpreter => true;
 }

--- a/docs/design/runtime-guide.md
+++ b/docs/design/runtime-guide.md
@@ -128,7 +128,7 @@ flowchart TD
 
 | Platform | `supportsReentrantInterpreter` | `maxConcurrentBridges` | Effect |
 |----------|-------------------------------|------------------------|--------|
-| Native | `true` | `128` | Many concurrent sessions |
+| Native | `true` | `4` (default) | Many concurrent sessions |
 | Web (WASM) | `false` | `1` | Single session; WASM guard blocks 2nd spawn |
 
 The WASM guard prevents deadlocks where a sub-agent tool call would


### PR DESCRIPTION
## Summary
- Rewrote package file tree: removed 7 non-existent files, fixed 2
  wrong locations, added 6 missing files
- Fixed RunOrchestrator constructor (`platform:` → `platformConstraints:`)
- Removed non-existent `RunRegistry`, `initialState` param, `eventStream`
- Fixed AgentSession: `result` is a getter, added `awaitResult()`,
  `cancel()` returns void
- Added `FailureReason reason` to AgentFailure, added `cancelled` variant
- Fixed ThreadKey sample code (added `serverId`)
- Fixed pubspec version/SDK constraints
- Fixed `maxConcurrentBridges` default (128/256 → 4) in runtime-guide
  and monty-host doc
- Fixed PlatformConstraints impl location in monty-host doc

## Changes
- **docs/design/soliplex-agent-package.md**: 11 sub-task fixes (3a-3i)
- **docs/design/runtime-guide.md**: maxConcurrentBridges default (3j)
- **docs/design/monty-host-capabilities-integration.md**: maxConcurrentBridges
  default + PlatformConstraints location (3j, 3k)

## Test plan
- [x] All changes verified against actual source code
- [x] `pymarkdown` scan passes on all 3 files
- [x] All pre-commit hooks pass