### PR TITLE
docs(audit): fix soliplex_scripting SPEC.md deviations

### DIFF
--- a/docs/design/monty-host-capabilities-integration.md
+++ b/docs/design/monty-host-capabilities-integration.md
@@ -1,3 +1,5 @@
+> **SUPERSEDED** by [PLANS/0008-soliplex-scripting/SPEC.md](../../PLANS/0008-soliplex-scripting/SPEC.md) — retained for historical context.
+
 # Monty HostApi Integration Guide
 
 ## Purpose


### PR DESCRIPTION
## Summary
- Fixed 8 spec-vs-code deviations in PLANS/0008-soliplex-scripting/SPEC.md
- Marked all 5 open questions as resolved with actual implementation outcomes
- Added superseded banner to monty-host-capabilities-integration.md

## Changes
- **PLANS/0008-soliplex-scripting/SPEC.md**:
  - 5a: Added threadId/runId fields to BridgeRunStarted/BridgeRunFinished
  - 5b: Updated PythonExecutorTool to abstract final class with static members
  - 5c: Updated AgUiBridgeAdapter from free function to class
  - 5d: BridgeCache constructor: PlatformConstraints → int limit
  - 5e: MontyToolExecutor takes threadKey at construction
  - 5f: _collectTextResult accumulates BridgeTextContent only
  - 5g: Added soliplex_client to dependency graph
  - 5h: Marked all 5 open questions resolved
- **docs/design/monty-host-capabilities-integration.md**: Added superseded banner

## Test plan
- [x] All changes verified against actual source code
- [x] `pymarkdown` scan passes
- [x] Pre-commit hooks pass