### PR TITLE
feat(skills): add soliplex_skills package

### DIFF
--- a/packages/soliplex_skills/analysis_options.yaml
+++ b/packages/soliplex_skills/analysis_options.yaml
@@ -1,0 +1,12 @@
+include: package:very_good_analysis/analysis_options.10.0.0.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    public_member_api_docs: false
+    one_member_abstracts: false

--- a/packages/soliplex_skills/lib/soliplex_skills.dart
+++ b/packages/soliplex_skills/lib/soliplex_skills.dart
@@ -1,0 +1,13 @@
+/// Shared skill loading and execution for Soliplex.
+library;
+
+export 'src/executor/markdown_skill_executor.dart';
+export 'src/executor/python_skill_executor.dart';
+export 'src/executor/skill_executor.dart';
+export 'src/loader/filesystem_skill_source.dart';
+export 'src/loader/server_skill_source.dart';
+export 'src/loader/skill_parser.dart';
+export 'src/loader/skill_source.dart';
+export 'src/model/skill.dart';
+export 'src/model/skill_metadata.dart';
+export 'src/registry/skill_registry.dart';

--- a/packages/soliplex_skills/lib/src/executor/markdown_skill_executor.dart
+++ b/packages/soliplex_skills/lib/src/executor/markdown_skill_executor.dart
@@ -1,0 +1,10 @@
+import 'package:soliplex_skills/src/executor/skill_executor.dart';
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Executes a [MarkdownSkill] by returning its content as a [MessageInjection].
+MessageInjection executeMarkdownSkill(MarkdownSkill skill) {
+  final roleStr = skill.metadata.extra['role'] as String?;
+  final role = roleStr == 'user' ? MessageRole.user : MessageRole.system;
+
+  return MessageInjection(role: role, content: skill.content);
+}

--- a/packages/soliplex_skills/lib/src/executor/python_skill_executor.dart
+++ b/packages/soliplex_skills/lib/src/executor/python_skill_executor.dart
@@ -1,0 +1,15 @@
+import 'package:soliplex_skills/src/executor/skill_executor.dart';
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Executes a [PythonSkill] by delegating to the injected [PythonRunner].
+Future<ExecutionOutput> executePythonSkill(
+  PythonSkill skill,
+  PythonRunner runner,
+) async {
+  try {
+    final output = await runner(skill.code);
+    return ExecutionOutput(output: output);
+  } on Exception catch (e) {
+    return ExecutionOutput(output: '', error: e.toString());
+  }
+}

--- a/packages/soliplex_skills/lib/src/executor/skill_executor.dart
+++ b/packages/soliplex_skills/lib/src/executor/skill_executor.dart
@@ -1,0 +1,76 @@
+import 'package:meta/meta.dart';
+
+/// Role for an injected message.
+enum MessageRole {
+  /// Injected as a system message.
+  system,
+
+  /// Injected as a user message.
+  user,
+}
+
+/// Result of executing a skill.
+@immutable
+sealed class SkillResult {
+  const SkillResult();
+}
+
+/// A chat message to inject from a Markdown skill.
+@immutable
+final class MessageInjection extends SkillResult {
+  const MessageInjection({required this.role, required this.content});
+
+  /// The role the message should be injected as.
+  final MessageRole role;
+
+  /// The message content.
+  final String content;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MessageInjection &&
+          runtimeType == other.runtimeType &&
+          role == other.role &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, role, content);
+
+  @override
+  String toString() => 'MessageInjection(role: $role)';
+}
+
+/// Output from executing a Python skill.
+@immutable
+final class ExecutionOutput extends SkillResult {
+  const ExecutionOutput({required this.output, this.error});
+
+  /// Standard output from the execution.
+  final String output;
+
+  /// Error message, if execution failed.
+  final String? error;
+
+  /// Whether execution completed without errors.
+  bool get isSuccess => error == null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExecutionOutput &&
+          runtimeType == other.runtimeType &&
+          output == other.output &&
+          error == other.error;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, output, error);
+
+  @override
+  String toString() => 'ExecutionOutput(success: $isSuccess)';
+}
+
+/// Signature for a function that executes Python code and returns output.
+///
+/// Injected by the host (Flutter app or TUI) to decouple from Monty.
+typedef PythonRunner = Future<String> Function(String code);

--- a/packages/soliplex_skills/lib/src/loader/filesystem_skill_source.dart
+++ b/packages/soliplex_skills/lib/src/loader/filesystem_skill_source.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:soliplex_skills/src/loader/skill_parser.dart';
+import 'package:soliplex_skills/src/loader/skill_source.dart';
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Loads skills from a local filesystem directory.
+///
+/// Recognises two layouts:
+/// - **Directory skills:** `skill-name/SKILL.md`
+/// - **Flat files:** `name.md`, `name.py`
+class FilesystemSkillSource implements SkillSource {
+  const FilesystemSkillSource(this.directory);
+
+  /// Root directory to scan for skill files.
+  final Directory directory;
+
+  @override
+  Future<List<Skill>> loadAll() async {
+    if (!directory.existsSync()) return [];
+
+    final skills = <Skill>[];
+    final errors = <SkillLoadException>[];
+
+    await for (final entity in directory.list()) {
+      try {
+        if (entity is Directory) {
+          final skillMd = File(p.join(entity.path, 'SKILL.md'));
+          if (skillMd.existsSync()) {
+            final raw = await skillMd.readAsString();
+            skills.add(SkillParser.parseMarkdown(skillMd.path, raw));
+          }
+        } else if (entity is File) {
+          final ext = p.extension(entity.path).toLowerCase();
+          final raw = await entity.readAsString();
+
+          if (ext == '.md') {
+            skills.add(SkillParser.parseMarkdown(entity.path, raw));
+          } else if (ext == '.py') {
+            final sidecarPath = '${p.withoutExtension(entity.path)}.yaml';
+            final sidecarFile = File(sidecarPath);
+            final sidecarYaml = sidecarFile.existsSync()
+                ? await sidecarFile.readAsString()
+                : null;
+            skills.add(
+              SkillParser.parsePython(
+                entity.path,
+                raw,
+                sidecarYaml: sidecarYaml,
+              ),
+            );
+          }
+        }
+      } on Exception catch (e) {
+        errors.add(
+          SkillLoadException(entity.path, 'Failed to load skill', e),
+        );
+      }
+    }
+
+    if (errors.isNotEmpty) {
+      // Errors are collected but not thrown — the caller gets what loaded.
+      // In the future, loadAll could return (List<Skill>, List<Exception>).
+    }
+
+    return skills;
+  }
+}

--- a/packages/soliplex_skills/lib/src/loader/server_skill_source.dart
+++ b/packages/soliplex_skills/lib/src/loader/server_skill_source.dart
@@ -1,0 +1,15 @@
+import 'package:soliplex_skills/src/loader/skill_source.dart';
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Loads skills from a remote server.
+///
+// TODO(skills): implement server-backed skill loading via API.
+class ServerSkillSource implements SkillSource {
+  const ServerSkillSource({required this.baseUrl});
+
+  /// Base URL of the skill server API.
+  final String baseUrl;
+
+  @override
+  Future<List<Skill>> loadAll() async => [];
+}

--- a/packages/soliplex_skills/lib/src/loader/skill_parser.dart
+++ b/packages/soliplex_skills/lib/src/loader/skill_parser.dart
@@ -1,0 +1,151 @@
+import 'package:soliplex_skills/src/model/skill.dart';
+import 'package:soliplex_skills/src/model/skill_metadata.dart';
+import 'package:yaml/yaml.dart';
+
+/// Parses skill files into [Skill] instances.
+abstract final class SkillParser {
+  /// Splits YAML frontmatter from body content.
+  ///
+  /// Frontmatter is delimited by `---` on its own line at the start.
+  /// Returns `(yamlMap, bodyAfterFrontmatter)`.
+  /// If no frontmatter is found, returns `({}, originalContent)`.
+  static (Map<String, dynamic>, String) extractFrontmatter(String content) {
+    final trimmed = content.trimLeft();
+    if (!trimmed.startsWith('---')) {
+      return (<String, dynamic>{}, content);
+    }
+
+    final afterOpening = trimmed.substring(3);
+    final closeIndex = afterOpening.indexOf('\n---');
+    if (closeIndex == -1) {
+      return (<String, dynamic>{}, content);
+    }
+
+    final yamlBlock = afterOpening.substring(0, closeIndex).trim();
+    final body = afterOpening.substring(closeIndex + 4).trimLeft();
+
+    final parsed = loadYaml(yamlBlock);
+    if (parsed is! YamlMap) {
+      return (<String, dynamic>{}, content);
+    }
+
+    final map = <String, dynamic>{};
+    for (final entry in parsed.entries) {
+      map[entry.key as String] = _convertYaml(entry.value);
+    }
+
+    return (map, body);
+  }
+
+  /// Parses a `.md` file into a [MarkdownSkill].
+  static MarkdownSkill parseMarkdown(String path, String raw) {
+    final (frontmatter, body) = extractFrontmatter(raw);
+    final metadata = _metadataFromMap(frontmatter, path);
+    return MarkdownSkill(
+      metadata: metadata,
+      sourcePath: path,
+      content: body,
+    );
+  }
+
+  /// Parses a `.py` file into a [PythonSkill].
+  ///
+  /// Metadata is extracted from a YAML frontmatter block in the module
+  /// docstring (triple-quoted string at the start of the file), or from
+  /// a sidecar `.yaml` file if provided via [sidecarYaml].
+  static PythonSkill parsePython(
+    String path,
+    String raw, {
+    String? sidecarYaml,
+  }) {
+    Map<String, dynamic> frontmatter;
+    String code;
+
+    if (sidecarYaml != null) {
+      final parsed = loadYaml(sidecarYaml);
+      frontmatter = parsed is YamlMap ? _yamlMapToMap(parsed) : {};
+      code = raw;
+    } else {
+      final docstring = _extractDocstring(raw);
+      if (docstring != null) {
+        (frontmatter, _) = extractFrontmatter(docstring);
+      } else {
+        frontmatter = {};
+      }
+      code = raw;
+    }
+
+    final metadata = _metadataFromMap(frontmatter, path);
+    return PythonSkill(
+      metadata: metadata,
+      sourcePath: path,
+      code: code,
+    );
+  }
+
+  static SkillMetadata _metadataFromMap(
+    Map<String, dynamic> map,
+    String path,
+  ) {
+    final metaSection = map['metadata'] is Map<String, dynamic>
+        ? map['metadata'] as Map<String, dynamic>
+        : const <String, dynamic>{};
+
+    // Build extra map excluding known keys.
+    final extra = <String, dynamic>{};
+    for (final entry in metaSection.entries) {
+      final key = entry.key;
+      if (key != 'bridge_version' && key != 'category' && key != 'generated') {
+        extra[key] = entry.value;
+      }
+    }
+
+    // Derive name from frontmatter or filename.
+    final name = map['name'] as String? ?? _nameFromPath(path);
+
+    return SkillMetadata(
+      name: name,
+      description: map['description'] as String? ?? '',
+      category: metaSection['category'] as String?,
+      bridgeVersion: metaSection['bridge_version'] as String?,
+      isGenerated: metaSection['generated'] == 'true' ||
+          metaSection['generated'] == true,
+      extra: extra,
+    );
+  }
+
+  static String _nameFromPath(String path) {
+    final segments = path.split('/');
+    final filename = segments.last;
+    final dotIndex = filename.lastIndexOf('.');
+    return dotIndex > 0 ? filename.substring(0, dotIndex) : filename;
+  }
+
+  /// Extracts a triple-quoted docstring from the start of a Python file.
+  static String? _extractDocstring(String code) {
+    final trimmed = code.trimLeft();
+
+    for (final quote in ['"""', "'''"]) {
+      if (!trimmed.startsWith(quote)) continue;
+      final after = trimmed.substring(quote.length);
+      final endIndex = after.indexOf(quote);
+      if (endIndex == -1) continue;
+      return after.substring(0, endIndex).trim();
+    }
+    return null;
+  }
+
+  static dynamic _convertYaml(dynamic value) {
+    if (value is YamlMap) return _yamlMapToMap(value);
+    if (value is YamlList) return value.map(_convertYaml).toList();
+    return value;
+  }
+
+  static Map<String, dynamic> _yamlMapToMap(YamlMap yamlMap) {
+    final map = <String, dynamic>{};
+    for (final entry in yamlMap.entries) {
+      map[entry.key as String] = _convertYaml(entry.value);
+    }
+    return map;
+  }
+}

--- a/packages/soliplex_skills/lib/src/loader/skill_source.dart
+++ b/packages/soliplex_skills/lib/src/loader/skill_source.dart
@@ -1,0 +1,24 @@
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Interface for loading skills from a source (filesystem, server, etc.).
+abstract class SkillSource {
+  /// Loads all available skills from this source.
+  Future<List<Skill>> loadAll();
+}
+
+/// Error encountered while loading a skill.
+class SkillLoadException implements Exception {
+  const SkillLoadException(this.path, this.message, [this.cause]);
+
+  /// Path or identifier of the skill that failed to load.
+  final String path;
+
+  /// Human-readable description of the failure.
+  final String message;
+
+  /// Underlying exception, if any.
+  final Object? cause;
+
+  @override
+  String toString() => 'SkillLoadException($path): $message';
+}

--- a/packages/soliplex_skills/lib/src/model/skill.dart
+++ b/packages/soliplex_skills/lib/src/model/skill.dart
@@ -1,0 +1,70 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_skills/src/model/skill_metadata.dart';
+
+/// A loadable skill — either a Markdown prompt or Python code.
+@immutable
+sealed class Skill {
+  const Skill({required this.metadata, required this.sourcePath});
+
+  /// Parsed frontmatter metadata.
+  final SkillMetadata metadata;
+
+  /// Filesystem path or URI where the skill was loaded from.
+  final String sourcePath;
+}
+
+/// A Markdown skill whose body is injected as a chat message.
+@immutable
+final class MarkdownSkill extends Skill {
+  const MarkdownSkill({
+    required super.metadata,
+    required super.sourcePath,
+    required this.content,
+  });
+
+  /// Markdown body after the frontmatter.
+  final String content;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MarkdownSkill &&
+          runtimeType == other.runtimeType &&
+          metadata == other.metadata &&
+          sourcePath == other.sourcePath &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, metadata, sourcePath, content);
+
+  @override
+  String toString() => 'MarkdownSkill(name: ${metadata.name})';
+}
+
+/// A Python skill executed in the Monty sandbox.
+@immutable
+final class PythonSkill extends Skill {
+  const PythonSkill({
+    required super.metadata,
+    required super.sourcePath,
+    required this.code,
+  });
+
+  /// Python source code.
+  final String code;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PythonSkill &&
+          runtimeType == other.runtimeType &&
+          metadata == other.metadata &&
+          sourcePath == other.sourcePath &&
+          code == other.code;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, metadata, sourcePath, code);
+
+  @override
+  String toString() => 'PythonSkill(name: ${metadata.name})';
+}

--- a/packages/soliplex_skills/lib/src/model/skill_metadata.dart
+++ b/packages/soliplex_skills/lib/src/model/skill_metadata.dart
@@ -1,0 +1,56 @@
+import 'package:meta/meta.dart';
+
+/// Metadata extracted from a skill's YAML frontmatter.
+@immutable
+class SkillMetadata {
+  const SkillMetadata({
+    required this.name,
+    required this.description,
+    this.category,
+    this.bridgeVersion,
+    this.isGenerated = false,
+    this.extra = const {},
+  });
+
+  /// Skill identifier (e.g. `"monty-df"`).
+  final String name;
+
+  /// Human-readable description of what the skill does.
+  final String description;
+
+  /// Optional grouping category (e.g. `"df"`, `"chart"`).
+  final String? category;
+
+  /// Bridge API version this skill targets.
+  final String? bridgeVersion;
+
+  /// Whether this skill was auto-generated.
+  final bool isGenerated;
+
+  /// Additional key-value pairs from frontmatter metadata.
+  final Map<String, dynamic> extra;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SkillMetadata &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          description == other.description &&
+          category == other.category &&
+          bridgeVersion == other.bridgeVersion &&
+          isGenerated == other.isGenerated;
+
+  @override
+  int get hashCode => Object.hash(
+        runtimeType,
+        name,
+        description,
+        category,
+        bridgeVersion,
+        isGenerated,
+      );
+
+  @override
+  String toString() => 'SkillMetadata(name: $name, category: $category)';
+}

--- a/packages/soliplex_skills/lib/src/registry/skill_registry.dart
+++ b/packages/soliplex_skills/lib/src/registry/skill_registry.dart
@@ -1,0 +1,92 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_skills/src/loader/skill_source.dart';
+import 'package:soliplex_skills/src/model/skill.dart';
+
+/// Immutable registry of loaded skills.
+///
+/// Every mutation returns a new [SkillRegistry] instance.
+@immutable
+class SkillRegistry {
+  /// Creates an empty registry.
+  const SkillRegistry() : _skills = const {};
+
+  const SkillRegistry._(this._skills);
+
+  final Map<String, Skill> _skills;
+
+  /// Registers a single [skill] and returns a new registry containing it.
+  SkillRegistry register(Skill skill) {
+    return SkillRegistry._({..._skills, skill.metadata.name: skill});
+  }
+
+  /// Registers multiple [skills] and returns a new registry containing them.
+  SkillRegistry registerAll(Iterable<Skill> skills) {
+    final updated = {..._skills};
+    for (final skill in skills) {
+      updated[skill.metadata.name] = skill;
+    }
+    return SkillRegistry._(updated);
+  }
+
+  /// Returns the skill registered under [name].
+  ///
+  /// Throws [StateError] if not found.
+  Skill lookup(String name) {
+    final skill = _skills[name];
+    if (skill == null) {
+      throw StateError('No skill registered with name "$name"');
+    }
+    return skill;
+  }
+
+  /// Returns the skill registered under [name], or `null` if not found.
+  Skill? tryLookup(String name) => _skills[name];
+
+  /// Whether a skill with [name] is registered.
+  bool contains(String name) => _skills.containsKey(name);
+
+  /// All registered skills.
+  List<Skill> get all => List.unmodifiable(_skills.values);
+
+  /// All registered [MarkdownSkill]s.
+  List<MarkdownSkill> get markdownSkills =>
+      _skills.values.whereType<MarkdownSkill>().toList(growable: false);
+
+  /// All registered [PythonSkill]s.
+  List<PythonSkill> get pythonSkills =>
+      _skills.values.whereType<PythonSkill>().toList(growable: false);
+
+  /// Skills matching a given [category].
+  List<Skill> byCategory(String category) => _skills.values
+      .where((s) => s.metadata.category == category)
+      .toList(growable: false);
+
+  /// Number of registered skills.
+  int get length => _skills.length;
+
+  /// Whether the registry is empty.
+  bool get isEmpty => _skills.isEmpty;
+}
+
+/// Loads skills from multiple [sources] into a [SkillRegistry].
+///
+/// Collects load errors without throwing so partial results are returned.
+Future<(SkillRegistry, List<SkillLoadException>)> loadSkillRegistry(
+  List<SkillSource> sources,
+) async {
+  var registry = const SkillRegistry();
+  final errors = <SkillLoadException>[];
+
+  for (final source in sources) {
+    try {
+      final skills = await source.loadAll();
+      registry = registry.registerAll(skills);
+    } on SkillLoadException catch (e) {
+      errors.add(e);
+    } on Exception catch (e) {
+      errors.add(SkillLoadException('unknown', e.toString(), e));
+    }
+  }
+
+  return (registry, errors);
+}

--- a/packages/soliplex_skills/pubspec.yaml
+++ b/packages/soliplex_skills/pubspec.yaml
@@ -1,0 +1,17 @@
+name: soliplex_skills
+description: >-
+  Shared skill loading and execution — higher-level composable behaviors
+  defined as .md (message injection) or .py (Python sandbox) files.
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  meta: ^1.9.0
+  path: ^1.8.0
+  yaml: ^3.1.0
+
+dev_dependencies:
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_skills/test/executor/markdown_skill_executor_test.dart
+++ b/packages/soliplex_skills/test/executor/markdown_skill_executor_test.dart
@@ -1,0 +1,52 @@
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('executeMarkdownSkill', () {
+    test('returns MessageInjection with system role by default', () {
+      const skill = MarkdownSkill(
+        metadata: SkillMetadata(name: 'sys', description: 'system prompt'),
+        sourcePath: '/skills/sys.md',
+        content: 'You are a helpful assistant.',
+      );
+
+      final result = executeMarkdownSkill(skill);
+
+      expect(result, isA<MessageInjection>());
+      expect(result.role, MessageRole.system);
+      expect(result.content, 'You are a helpful assistant.');
+    });
+
+    test('uses user role when specified in extra', () {
+      const skill = MarkdownSkill(
+        metadata: SkillMetadata(
+          name: 'usr',
+          description: 'user prompt',
+          extra: {'role': 'user'},
+        ),
+        sourcePath: '/skills/usr.md',
+        content: 'Please analyse this data.',
+      );
+
+      final result = executeMarkdownSkill(skill);
+
+      expect(result.role, MessageRole.user);
+      expect(result.content, 'Please analyse this data.');
+    });
+
+    test('defaults to system for unknown role value', () {
+      const skill = MarkdownSkill(
+        metadata: SkillMetadata(
+          name: 'x',
+          description: 'd',
+          extra: {'role': 'unknown'},
+        ),
+        sourcePath: '/x.md',
+        content: 'body',
+      );
+
+      final result = executeMarkdownSkill(skill);
+      expect(result.role, MessageRole.system);
+    });
+  });
+}

--- a/packages/soliplex_skills/test/executor/python_skill_executor_test.dart
+++ b/packages/soliplex_skills/test/executor/python_skill_executor_test.dart
@@ -1,0 +1,45 @@
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const skill = PythonSkill(
+    metadata: SkillMetadata(name: 'hello', description: 'says hello'),
+    sourcePath: '/skills/hello.py',
+    code: 'print("hello")',
+  );
+
+  group('executePythonSkill', () {
+    test('delegates to PythonRunner and returns output', () async {
+      Future<String> mockRunner(String code) async => 'hello';
+
+      final result = await executePythonSkill(skill, mockRunner);
+
+      expect(result, isA<ExecutionOutput>());
+      expect(result.output, 'hello');
+      expect(result.error, isNull);
+      expect(result.isSuccess, isTrue);
+    });
+
+    test('passes skill code to runner', () async {
+      String? receivedCode;
+      Future<String> capturingRunner(String code) async {
+        receivedCode = code;
+        return '';
+      }
+
+      await executePythonSkill(skill, capturingRunner);
+      expect(receivedCode, 'print("hello")');
+    });
+
+    test('captures runner exceptions as error', () async {
+      Future<String> failingRunner(String code) async =>
+          throw Exception('sandbox crashed');
+
+      final result = await executePythonSkill(skill, failingRunner);
+
+      expect(result.isSuccess, isFalse);
+      expect(result.output, '');
+      expect(result.error, contains('sandbox crashed'));
+    });
+  });
+}

--- a/packages/soliplex_skills/test/loader/filesystem_skill_source_test.dart
+++ b/packages/soliplex_skills/test/loader/filesystem_skill_source_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('skills_test_');
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  group('FilesystemSkillSource', () {
+    test('loads flat .md files', () async {
+      const content = '---\n'
+          'name: greeting\n'
+          'description: A greeting prompt\n'
+          '---\n'
+          'Hello, how can I help?';
+      File(p.join(tempDir.path, 'greeting.md')).writeAsStringSync(content);
+
+      final source = FilesystemSkillSource(tempDir);
+      final skills = await source.loadAll();
+
+      expect(skills, hasLength(1));
+      expect(skills.first, isA<MarkdownSkill>());
+      expect(skills.first.metadata.name, 'greeting');
+      expect(
+        (skills.first as MarkdownSkill).content,
+        'Hello, how can I help?',
+      );
+    });
+
+    test('loads flat .py files', () async {
+      File(p.join(tempDir.path, 'hello.py')).writeAsStringSync(
+        'print("hello")',
+      );
+
+      final source = FilesystemSkillSource(tempDir);
+      final skills = await source.loadAll();
+
+      expect(skills, hasLength(1));
+      expect(skills.first, isA<PythonSkill>());
+      expect(skills.first.metadata.name, 'hello');
+    });
+
+    test('loads directory-style SKILL.md', () async {
+      final skillDir = Directory(p.join(tempDir.path, 'my-skill'))
+        ..createSync();
+      const content = '---\n'
+          'name: my-skill\n'
+          'description: Directory skill\n'
+          '---\n'
+          'Body text.';
+      File(p.join(skillDir.path, 'SKILL.md')).writeAsStringSync(content);
+
+      final source = FilesystemSkillSource(tempDir);
+      final skills = await source.loadAll();
+
+      expect(skills, hasLength(1));
+      expect(skills.first, isA<MarkdownSkill>());
+      expect(skills.first.metadata.name, 'my-skill');
+    });
+
+    test('loads .py with sidecar .yaml', () async {
+      File(p.join(tempDir.path, 'calc.py')).writeAsStringSync(
+        'result = 1 + 2',
+      );
+      const sidecar = 'name: calc\n'
+          'description: Calculator\n'
+          'metadata:\n'
+          '  category: math\n';
+      File(p.join(tempDir.path, 'calc.yaml')).writeAsStringSync(sidecar);
+
+      final source = FilesystemSkillSource(tempDir);
+      final skills = await source.loadAll();
+
+      final pySkills = skills.whereType<PythonSkill>().toList();
+      expect(pySkills, hasLength(1));
+      expect(pySkills.first.metadata.name, 'calc');
+      expect(pySkills.first.metadata.category, 'math');
+    });
+
+    test('returns empty list for non-existent directory', () async {
+      final source = FilesystemSkillSource(
+        Directory(p.join(tempDir.path, 'nope')),
+      );
+      final skills = await source.loadAll();
+      expect(skills, isEmpty);
+    });
+
+    test('ignores non-.md/.py files', () async {
+      File(p.join(tempDir.path, 'readme.txt')).writeAsStringSync('ignore me');
+
+      final source = FilesystemSkillSource(tempDir);
+      final skills = await source.loadAll();
+      expect(skills, isEmpty);
+    });
+  });
+}

--- a/packages/soliplex_skills/test/loader/skill_parser_test.dart
+++ b/packages/soliplex_skills/test/loader/skill_parser_test.dart
@@ -1,0 +1,165 @@
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SkillParser.extractFrontmatter', () {
+    test('parses YAML between --- delimiters', () {
+      const raw = '---\n'
+          'name: test-skill\n'
+          'description: A test\n'
+          'metadata:\n'
+          '  category: charts\n'
+          '---\n'
+          '# Body content here';
+
+      final (map, body) = SkillParser.extractFrontmatter(raw);
+
+      expect(map['name'], 'test-skill');
+      expect(map['description'], 'A test');
+      expect((map['metadata'] as Map)['category'], 'charts');
+      expect(body, '# Body content here');
+    });
+
+    test('returns empty map when no frontmatter', () {
+      const raw = '# Just markdown\nNo frontmatter here.';
+      final (map, body) = SkillParser.extractFrontmatter(raw);
+
+      expect(map, isEmpty);
+      expect(body, raw);
+    });
+
+    test('returns empty map when only opening ---', () {
+      const raw = '---\nname: broken';
+      final (map, body) = SkillParser.extractFrontmatter(raw);
+
+      expect(map, isEmpty);
+      expect(body, raw);
+    });
+
+    test('handles leading whitespace', () {
+      const raw = '  ---\n'
+          'name: indented\n'
+          '---\n'
+          'body';
+
+      final (map, body) = SkillParser.extractFrontmatter(raw);
+      expect(map['name'], 'indented');
+      expect(body, 'body');
+    });
+  });
+
+  group('SkillParser.parseMarkdown', () {
+    test('parses frontmatter into SkillMetadata', () {
+      const raw = '---\n'
+          'name: monty-df\n'
+          'description: DataFrame operations\n'
+          'metadata:\n'
+          '  bridge_version: "1"\n'
+          '  category: df\n'
+          '  generated: "true"\n'
+          '---\n'
+          'You are a DataFrame assistant.';
+
+      final skill = SkillParser.parseMarkdown('/skills/monty-df.md', raw);
+
+      expect(skill, isA<MarkdownSkill>());
+      expect(skill.metadata.name, 'monty-df');
+      expect(skill.metadata.description, 'DataFrame operations');
+      expect(skill.metadata.category, 'df');
+      expect(skill.metadata.bridgeVersion, '1');
+      expect(skill.metadata.isGenerated, isTrue);
+      expect(skill.content, 'You are a DataFrame assistant.');
+      expect(skill.sourcePath, '/skills/monty-df.md');
+    });
+
+    test('derives name from filename when not in frontmatter', () {
+      const raw = '---\n'
+          'description: No name field\n'
+          '---\n'
+          'body';
+
+      final skill = SkillParser.parseMarkdown('/skills/my-skill.md', raw);
+      expect(skill.metadata.name, 'my-skill');
+    });
+
+    test('handles file with no frontmatter', () {
+      const raw = '# Just a markdown file';
+      final skill = SkillParser.parseMarkdown('/skills/plain.md', raw);
+
+      expect(skill.metadata.name, 'plain');
+      expect(skill.metadata.description, '');
+      expect(skill.content, raw);
+    });
+
+    test('preserves extra metadata keys', () {
+      const raw = '---\n'
+          'name: extra\n'
+          'description: has extras\n'
+          'metadata:\n'
+          '  category: test\n'
+          '  custom_key: custom_value\n'
+          '---\n'
+          'body';
+
+      final skill = SkillParser.parseMarkdown('/skills/extra.md', raw);
+      expect(skill.metadata.extra['custom_key'], 'custom_value');
+      expect(skill.metadata.extra.containsKey('category'), isFalse);
+    });
+  });
+
+  group('SkillParser.parsePython', () {
+    test('extracts metadata from docstring frontmatter', () {
+      const raw = '"""\n'
+          '---\n'
+          'name: hello\n'
+          'description: Says hello\n'
+          'metadata:\n'
+          '  category: demo\n'
+          '---\n'
+          '"""\n'
+          'print("hello")';
+
+      final skill = SkillParser.parsePython('/skills/hello.py', raw);
+
+      expect(skill, isA<PythonSkill>());
+      expect(skill.metadata.name, 'hello');
+      expect(skill.metadata.description, 'Says hello');
+      expect(skill.metadata.category, 'demo');
+      expect(skill.code, raw);
+    });
+
+    test('uses sidecar YAML when provided', () {
+      const code = 'print("hello")';
+      const sidecar = 'name: hello\n'
+          'description: Says hello\n'
+          'metadata:\n'
+          '  category: demo\n';
+
+      final skill = SkillParser.parsePython(
+        '/skills/hello.py',
+        code,
+        sidecarYaml: sidecar,
+      );
+
+      expect(skill.metadata.name, 'hello');
+      expect(skill.metadata.description, 'Says hello');
+      expect(skill.code, code);
+    });
+
+    test('derives name from filename when no metadata', () {
+      const code = 'x = 1';
+      final skill = SkillParser.parsePython('/skills/simple.py', code);
+
+      expect(skill.metadata.name, 'simple');
+      expect(skill.metadata.description, '');
+    });
+
+    test('handles single-quoted docstrings', () {
+      const raw =
+          "'''\n---\nname: single\ndescription: single quotes\n---\n'''\nx = 1";
+
+      final skill = SkillParser.parsePython('/skills/single.py', raw);
+      expect(skill.metadata.name, 'single');
+    });
+  });
+}

--- a/packages/soliplex_skills/test/model/skill_test.dart
+++ b/packages/soliplex_skills/test/model/skill_test.dart
@@ -1,0 +1,148 @@
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SkillMetadata', () {
+    test('constructs with required fields', () {
+      const meta = SkillMetadata(name: 'test', description: 'A test skill');
+      expect(meta.name, 'test');
+      expect(meta.description, 'A test skill');
+      expect(meta.category, isNull);
+      expect(meta.bridgeVersion, isNull);
+      expect(meta.isGenerated, isFalse);
+      expect(meta.extra, isEmpty);
+    });
+
+    test('equality compares all fields', () {
+      const a = SkillMetadata(
+        name: 'x',
+        description: 'd',
+        category: 'cat',
+      );
+      const b = SkillMetadata(
+        name: 'x',
+        description: 'd',
+        category: 'cat',
+      );
+      const c = SkillMetadata(
+        name: 'x',
+        description: 'd',
+        category: 'other',
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes name and category', () {
+      const meta = SkillMetadata(
+        name: 'foo',
+        description: 'bar',
+        category: 'charts',
+      );
+      expect(meta.toString(), contains('foo'));
+      expect(meta.toString(), contains('charts'));
+    });
+  });
+
+  group('MarkdownSkill', () {
+    test('constructs and exposes content', () {
+      const skill = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'desc'),
+        sourcePath: '/skills/md.md',
+        content: '# Hello',
+      );
+      expect(skill.metadata.name, 'md');
+      expect(skill.sourcePath, '/skills/md.md');
+      expect(skill.content, '# Hello');
+    });
+
+    test('equality includes content', () {
+      const a = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'd'),
+        sourcePath: '/a',
+        content: 'body',
+      );
+      const b = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'd'),
+        sourcePath: '/a',
+        content: 'body',
+      );
+      const c = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'd'),
+        sourcePath: '/a',
+        content: 'different',
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('is a Skill', () {
+      const skill = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'd'),
+        sourcePath: '/a',
+        content: '',
+      );
+      expect(skill, isA<Skill>());
+    });
+  });
+
+  group('PythonSkill', () {
+    test('constructs and exposes code', () {
+      const skill = PythonSkill(
+        metadata: SkillMetadata(name: 'py', description: 'desc'),
+        sourcePath: '/skills/py.py',
+        code: 'print("hi")',
+      );
+      expect(skill.metadata.name, 'py');
+      expect(skill.code, 'print("hi")');
+    });
+
+    test('equality includes code', () {
+      const a = PythonSkill(
+        metadata: SkillMetadata(name: 'py', description: 'd'),
+        sourcePath: '/a',
+        code: 'x = 1',
+      );
+      const b = PythonSkill(
+        metadata: SkillMetadata(name: 'py', description: 'd'),
+        sourcePath: '/a',
+        code: 'x = 1',
+      );
+      const c = PythonSkill(
+        metadata: SkillMetadata(name: 'py', description: 'd'),
+        sourcePath: '/a',
+        code: 'x = 2',
+      );
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('is a Skill', () {
+      const skill = PythonSkill(
+        metadata: SkillMetadata(name: 'py', description: 'd'),
+        sourcePath: '/a',
+        code: '',
+      );
+      expect(skill, isA<Skill>());
+    });
+  });
+
+  group('sealed Skill exhaustiveness', () {
+    test('switch covers all cases', () {
+      const Skill skill = MarkdownSkill(
+        metadata: SkillMetadata(name: 'md', description: 'd'),
+        sourcePath: '/a',
+        content: 'body',
+      );
+
+      final result = switch (skill) {
+        MarkdownSkill() => 'markdown',
+        PythonSkill() => 'python',
+      };
+      expect(result, 'markdown');
+    });
+  });
+}

--- a/packages/soliplex_skills/test/registry/skill_registry_test.dart
+++ b/packages/soliplex_skills/test/registry/skill_registry_test.dart
@@ -1,0 +1,134 @@
+import 'package:soliplex_skills/soliplex_skills.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const mdMeta = SkillMetadata(
+    name: 'prompt-a',
+    description: 'A prompt',
+    category: 'prompts',
+  );
+  const pyMeta = SkillMetadata(
+    name: 'script-b',
+    description: 'A script',
+    category: 'scripts',
+  );
+  const mdSkill = MarkdownSkill(
+    metadata: mdMeta,
+    sourcePath: '/a.md',
+    content: 'body',
+  );
+  const pySkill = PythonSkill(
+    metadata: pyMeta,
+    sourcePath: '/b.py',
+    code: 'x = 1',
+  );
+
+  group('SkillRegistry', () {
+    test('starts empty', () {
+      const registry = SkillRegistry();
+      expect(registry.isEmpty, isTrue);
+      expect(registry.length, 0);
+      expect(registry.all, isEmpty);
+    });
+
+    test('register returns new instance with skill', () {
+      const registry = SkillRegistry();
+      final updated = registry.register(mdSkill);
+
+      expect(registry.isEmpty, isTrue);
+      expect(updated.length, 1);
+      expect(updated.contains('prompt-a'), isTrue);
+    });
+
+    test('registerAll adds multiple skills', () {
+      const registry = SkillRegistry();
+      final updated = registry.registerAll([mdSkill, pySkill]);
+
+      expect(updated.length, 2);
+      expect(updated.contains('prompt-a'), isTrue);
+      expect(updated.contains('script-b'), isTrue);
+    });
+
+    test('lookup returns registered skill', () {
+      final registry = const SkillRegistry().register(mdSkill);
+      final found = registry.lookup('prompt-a');
+      expect(found, equals(mdSkill));
+    });
+
+    test('lookup throws for missing skill', () {
+      const registry = SkillRegistry();
+      expect(() => registry.lookup('nope'), throwsStateError);
+    });
+
+    test('tryLookup returns null for missing skill', () {
+      const registry = SkillRegistry();
+      expect(registry.tryLookup('nope'), isNull);
+    });
+
+    test('markdownSkills filters correctly', () {
+      final registry = const SkillRegistry().registerAll([mdSkill, pySkill]);
+      expect(registry.markdownSkills, [mdSkill]);
+    });
+
+    test('pythonSkills filters correctly', () {
+      final registry = const SkillRegistry().registerAll([mdSkill, pySkill]);
+      expect(registry.pythonSkills, [pySkill]);
+    });
+
+    test('byCategory filters correctly', () {
+      final registry = const SkillRegistry().registerAll([mdSkill, pySkill]);
+      expect(registry.byCategory('prompts'), [mdSkill]);
+      expect(registry.byCategory('scripts'), [pySkill]);
+      expect(registry.byCategory('other'), isEmpty);
+    });
+
+    test('later registration overwrites earlier by name', () {
+      const updated = MarkdownSkill(
+        metadata: mdMeta,
+        sourcePath: '/a-v2.md',
+        content: 'updated',
+      );
+      final registry =
+          const SkillRegistry().register(mdSkill).register(updated);
+
+      expect(registry.length, 1);
+      expect((registry.lookup('prompt-a') as MarkdownSkill).content, 'updated');
+    });
+  });
+
+  group('loadSkillRegistry', () {
+    test('loads from multiple sources', () async {
+      final source1 = _InMemorySource([mdSkill]);
+      final source2 = _InMemorySource([pySkill]);
+
+      final (registry, errors) = await loadSkillRegistry([source1, source2]);
+
+      expect(errors, isEmpty);
+      expect(registry.length, 2);
+    });
+
+    test('collects errors without throwing', () async {
+      final good = _InMemorySource([mdSkill]);
+      final bad = _FailingSource();
+
+      final (registry, errors) = await loadSkillRegistry([good, bad]);
+
+      expect(registry.length, 1);
+      expect(errors, hasLength(1));
+    });
+  });
+}
+
+class _InMemorySource implements SkillSource {
+  _InMemorySource(this._skills);
+  final List<Skill> _skills;
+
+  @override
+  Future<List<Skill>> loadAll() async => _skills;
+}
+
+class _FailingSource implements SkillSource {
+  @override
+  Future<List<Skill>> loadAll() async =>
+      throw const SkillLoadException('test', 'boom');
+}


### PR DESCRIPTION
## Summary
- New pure Dart `soliplex_skills` package for loading and executing composable skills
- Skills are `.md` files (injected as chat messages) or `.py` files (run in Python sandbox)
- No Flutter SDK or `soliplex_monty` dependency — Python execution injected via `PythonRunner` typedef

## Changes
- **Models**: Sealed `Skill` class (`MarkdownSkill`, `PythonSkill`) with `SkillMetadata` from YAML frontmatter
- **Parser**: `SkillParser` extracts frontmatter, classifies `.md`/`.py` files, supports sidecar `.yaml`
- **Registry**: Immutable `SkillRegistry` with `register`/`lookup`/`byCategory` (follows `ToolRegistry` pattern)
- **Loaders**: `FilesystemSkillSource` (flat files + `SKILL.md` directories), `ServerSkillSource` (stub)
- **Executors**: `MarkdownSkillExecutor` returns `MessageInjection`, `PythonSkillExecutor` delegates to injected runner

## Test plan
- [x] 46 unit tests covering models, parser, registry, loaders, and executors
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart test` — all passing