### PR TITLE
feat(schema): add soliplex_schema package

### DIFF
--- a/packages/soliplex_schema/analysis_options.yaml
+++ b/packages/soliplex_schema/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/packages/soliplex_schema/lib/soliplex_schema.dart
+++ b/packages/soliplex_schema/lib/soliplex_schema.dart
@@ -1,0 +1,6 @@
+export 'src/feature_schema.dart';
+export 'src/feature_schema_registry.dart';
+export 'src/field_schema.dart';
+export 'src/object_schema.dart';
+export 'src/schema_parser.dart';
+export 'src/schema_state_view.dart';

--- a/packages/soliplex_schema/lib/src/feature_schema.dart
+++ b/packages/soliplex_schema/lib/src/feature_schema.dart
@@ -1,0 +1,46 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_schema/src/object_schema.dart';
+
+/// The source that owns a feature's state.
+enum FeatureSource {
+  /// Only the client can write.
+  client,
+
+  /// Only the server can write.
+  server,
+
+  /// Both client and server can write.
+  either;
+
+  /// Parses a source string from the backend API.
+  static FeatureSource fromString(String value) {
+    return switch (value.toLowerCase()) {
+      'client' => FeatureSource.client,
+      'server' => FeatureSource.server,
+      _ => FeatureSource.either,
+    };
+  }
+}
+
+/// Domain model for one AG-UI feature schema.
+@immutable
+class FeatureSchema {
+  const FeatureSchema({
+    required this.name,
+    required this.description,
+    required this.source,
+    required this.objectSchema,
+  });
+
+  /// The feature key in AG-UI state (e.g., `"haiku.rag.chat"`).
+  final String name;
+
+  /// Human-readable description from the Pydantic model docstring.
+  final String description;
+
+  /// Which side owns writes to this feature's state.
+  final FeatureSource source;
+
+  /// The parsed JSON Schema for this feature's state object.
+  final ObjectSchema objectSchema;
+}

--- a/packages/soliplex_schema/lib/src/feature_schema_registry.dart
+++ b/packages/soliplex_schema/lib/src/feature_schema_registry.dart
@@ -1,0 +1,111 @@
+import 'package:soliplex_schema/src/feature_schema.dart';
+import 'package:soliplex_schema/src/object_schema.dart';
+import 'package:soliplex_schema/src/schema_parser.dart';
+import 'package:soliplex_schema/src/schema_state_view.dart';
+
+/// Cache of parsed feature schemas: roomId → featureName →
+/// [FeatureSchema].
+///
+/// Schemas are parsed once on registration and reused for every
+/// state view created.
+class FeatureSchemaRegistry {
+  final _cache = <String, Map<String, FeatureSchema>>{};
+  final _parser = SchemaParser();
+
+  /// Registers feature schemas for a room from the raw API response.
+  ///
+  /// [roomId] is the room identifier.
+  /// [rawFeatures] is the map of feature name → raw feature object
+  /// as returned by `GET /rooms/{roomId}/feature_schemas`.
+  ///
+  /// Each raw feature object has shape:
+  /// ```json
+  /// {
+  ///   "name": "haiku.rag.chat",
+  ///   "description": "...",
+  ///   "source": "SERVER",
+  ///   "json_schema": { ... }
+  /// }
+  /// ```
+  void register(
+    String roomId,
+    Map<String, Map<String, dynamic>> rawFeatures,
+  ) {
+    final features = <String, FeatureSchema>{};
+    for (final entry in rawFeatures.entries) {
+      final raw = entry.value;
+      final jsonSchema =
+          raw['json_schema'] as Map<String, dynamic>? ?? const {};
+      final objectSchema = _parser.parse(jsonSchema);
+
+      features[entry.key] = FeatureSchema(
+        name: raw['name'] as String? ?? entry.key,
+        description: raw['description'] as String? ?? '',
+        source: FeatureSource.fromString(
+          raw['source'] as String? ?? 'EITHER',
+        ),
+        objectSchema: objectSchema,
+      );
+    }
+    _cache[roomId] = features;
+  }
+
+  /// Returns the [FeatureSchema] for [featureName] in [roomId],
+  /// or `null` if not registered.
+  FeatureSchema? getSchema(String roomId, String featureName) {
+    return _cache[roomId]?[featureName];
+  }
+
+  /// Returns all registered feature schemas for [roomId].
+  Map<String, FeatureSchema> getSchemas(String roomId) {
+    return _cache[roomId] ?? const {};
+  }
+
+  /// Whether schemas have been registered for [roomId].
+  bool hasRoom(String roomId) => _cache.containsKey(roomId);
+
+  /// Creates a [SchemaStateView] for [featureName] in [roomId]
+  /// using the given [aguiState].
+  ///
+  /// The [aguiState] is the full AG-UI state map. This method
+  /// extracts the feature-specific sub-map and wraps it with the
+  /// parsed schema.
+  ///
+  /// Returns `null` if the feature is not registered or absent
+  /// from the state.
+  SchemaStateView? viewFor(
+    String roomId,
+    String featureName,
+    Map<String, dynamic> aguiState,
+  ) {
+    final featureSchema = getSchema(roomId, featureName);
+    if (featureSchema == null) return null;
+
+    final data = aguiState[featureName];
+    if (data == null || data is! Map<String, dynamic>) return null;
+
+    return SchemaStateView(data, featureSchema.objectSchema);
+  }
+
+  /// Creates a [SchemaStateView] directly from a feature's data
+  /// map and its [ObjectSchema].
+  ///
+  /// Use this when you already have the schema (e.g., from
+  /// [getSchema]) and the feature-specific data map.
+  static SchemaStateView viewFromSchema(
+    Map<String, dynamic> data,
+    ObjectSchema schema,
+  ) {
+    return SchemaStateView(data, schema);
+  }
+
+  /// Removes cached schemas for [roomId].
+  void evict(String roomId) {
+    _cache.remove(roomId);
+  }
+
+  /// Removes all cached schemas.
+  void clear() {
+    _cache.clear();
+  }
+}

--- a/packages/soliplex_schema/lib/src/field_schema.dart
+++ b/packages/soliplex_schema/lib/src/field_schema.dart
@@ -1,0 +1,89 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_schema/src/object_schema.dart';
+
+/// The JSON Schema type of a field.
+enum FieldType {
+  /// A string value.
+  string,
+
+  /// An integer value.
+  integer,
+
+  /// A floating-point number.
+  number,
+
+  /// A boolean value.
+  boolean,
+
+  /// A nested object (has its own [ObjectSchema]).
+  object,
+
+  /// A homogeneous array.
+  array,
+
+  /// A map with string keys (JSON Schema `additionalProperties`).
+  map,
+}
+
+/// Parsed metadata for one JSON Schema property.
+@immutable
+class FieldSchema {
+  const FieldSchema({
+    required this.name,
+    required this.type,
+    this.nullable = false,
+    this.required = false,
+    this.defaultValue,
+    this.format,
+    this.title,
+    this.description,
+    this.objectSchema,
+    this.itemSchema,
+    this.itemType,
+    this.valueType,
+    this.valueObjectSchema,
+    this.nestedItemSchema,
+  });
+
+  /// The property name as it appears in JSON (snake_case).
+  final String name;
+
+  /// The resolved field type.
+  final FieldType type;
+
+  /// Whether the field is nullable (`anyOf: [T, null]`).
+  final bool nullable;
+
+  /// Whether the field is in the parent's `required` list.
+  final bool required;
+
+  /// The default value from the schema, if any.
+  final Object? defaultValue;
+
+  /// The `format` keyword (e.g., `"date-time"`).
+  final String? format;
+
+  /// The `title` keyword.
+  final String? title;
+
+  /// The `description` keyword.
+  final String? description;
+
+  /// For [FieldType.object]: the schema of the nested object.
+  final ObjectSchema? objectSchema;
+
+  /// For [FieldType.array] with object items: the schema of each item.
+  final ObjectSchema? itemSchema;
+
+  /// For [FieldType.array] with scalar items: the scalar type.
+  final FieldType? itemType;
+
+  /// For [FieldType.map]: the type of map values.
+  final FieldType? valueType;
+
+  /// For [FieldType.map] with object values: the schema of each value.
+  final ObjectSchema? valueObjectSchema;
+
+  /// For nested arrays (array of arrays): the inner item schema.
+  final FieldSchema? nestedItemSchema;
+}

--- a/packages/soliplex_schema/lib/src/object_schema.dart
+++ b/packages/soliplex_schema/lib/src/object_schema.dart
@@ -1,0 +1,24 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_schema/src/field_schema.dart';
+
+/// Parsed JSON Schema object with its field map.
+@immutable
+class ObjectSchema {
+  const ObjectSchema({
+    required this.fields,
+    this.title,
+    this.description,
+  });
+
+  /// Fields keyed by JSON property name (snake_case).
+  final Map<String, FieldSchema> fields;
+
+  /// The `title` keyword from the schema.
+  final String? title;
+
+  /// The `description` keyword from the schema.
+  final String? description;
+
+  /// Returns the [FieldSchema] for [name], or `null` if absent.
+  FieldSchema? operator [](String name) => fields[name];
+}

--- a/packages/soliplex_schema/lib/src/schema_parser.dart
+++ b/packages/soliplex_schema/lib/src/schema_parser.dart
@@ -1,0 +1,382 @@
+import 'package:soliplex_schema/src/field_schema.dart';
+import 'package:soliplex_schema/src/object_schema.dart';
+
+/// Parses a raw JSON Schema map into an [ObjectSchema].
+///
+/// Handles:
+/// - `$ref` → `$defs` resolution (scoped per schema)
+/// - `anyOf: [{type: T}, {type: null}]` → nullable
+/// - `anyOf: [{$ref: ...}, {type: null}]` → nullable object
+/// - `items` for arrays (scalar, object, and nested arrays)
+/// - `additionalProperties` for maps
+/// - `default` values
+/// - `required` field sets
+/// - `num` → `int`/`double` coercion
+/// - `format` keyword preservation
+class SchemaParser {
+  /// Parses a JSON Schema object into an [ObjectSchema].
+  ///
+  /// The [schema] should be a decoded JSON Schema with `type: "object"`
+  /// and `properties`.
+  ObjectSchema parse(Map<String, dynamic> schema) {
+    final defs = _parseDefs(schema);
+    return _parseObject(schema, defs);
+  }
+
+  /// Extracts `$defs` from a schema and parses each into an
+  /// [ObjectSchema].
+  Map<String, ObjectSchema> _parseDefs(Map<String, dynamic> schema) {
+    final rawDefs = schema[r'$defs'] as Map<String, dynamic>?;
+    if (rawDefs == null) return const {};
+
+    // Two-pass: first create empty placeholders, then fill them.
+    // This allows circular $ref (unlikely but safe).
+    final defs = <String, ObjectSchema>{};
+    for (final entry in rawDefs.entries) {
+      final defSchema = entry.value as Map<String, dynamic>;
+      defs[entry.key] = _parseObject(defSchema, defs);
+    }
+    return defs;
+  }
+
+  /// Parses an object schema (has `properties`).
+  ObjectSchema _parseObject(
+    Map<String, dynamic> schema,
+    Map<String, ObjectSchema> defs,
+  ) {
+    final properties =
+        schema['properties'] as Map<String, dynamic>? ?? const {};
+    final requiredList = schema['required'] as List<dynamic>? ?? const [];
+    final requiredSet = requiredList.cast<String>().toSet();
+
+    final fields = <String, FieldSchema>{};
+    for (final entry in properties.entries) {
+      final propSchema = entry.value as Map<String, dynamic>;
+      fields[entry.key] = _parseField(
+        entry.key,
+        propSchema,
+        defs,
+        isRequired: requiredSet.contains(entry.key),
+      );
+    }
+
+    return ObjectSchema(
+      fields: fields,
+      title: schema['title'] as String?,
+      description: schema['description'] as String?,
+    );
+  }
+
+  /// Parses a single property schema into a [FieldSchema].
+  FieldSchema _parseField(
+    String name,
+    Map<String, dynamic> schema,
+    Map<String, ObjectSchema> defs, {
+    bool isRequired = false,
+  }) {
+    final defaultValue = schema['default'];
+    final title = schema['title'] as String?;
+    final description = schema['description'] as String?;
+    final format = schema['format'] as String?;
+
+    // Check for $ref first (direct object reference).
+    if (schema.containsKey(r'$ref')) {
+      final resolved = _resolveRef(schema[r'$ref'] as String, defs);
+      return FieldSchema(
+        name: name,
+        type: FieldType.object,
+        required: isRequired,
+        defaultValue: defaultValue,
+        title: title,
+        description: description,
+        objectSchema: resolved,
+      );
+    }
+
+    // Check for anyOf (nullable pattern).
+    final anyOf = schema['anyOf'] as List<dynamic>?;
+    if (anyOf != null) {
+      return _parseAnyOf(
+        name,
+        anyOf.cast<Map<String, dynamic>>(),
+        defs,
+        isRequired: isRequired,
+        defaultValue: defaultValue,
+        title: title,
+        description: description,
+        format: format,
+      );
+    }
+
+    // Standard type-based parsing.
+    final type = schema['type'] as String?;
+    return _parseTyped(
+      name,
+      type ?? 'object',
+      schema,
+      defs,
+      isRequired: isRequired,
+      defaultValue: defaultValue,
+      title: title,
+      description: description,
+      format: format,
+    );
+  }
+
+  /// Parses an `anyOf` schema (nullable pattern).
+  ///
+  /// Recognizes `anyOf: [{type/ref: T}, {type: null}]`.
+  FieldSchema _parseAnyOf(
+    String name,
+    List<Map<String, dynamic>> anyOf,
+    Map<String, ObjectSchema> defs, {
+    bool isRequired = false,
+    Object? defaultValue,
+    String? title,
+    String? description,
+    String? format,
+  }) {
+    // Filter out the null variant.
+    final nonNull = anyOf.where((s) => s['type'] != 'null').toList();
+
+    if (nonNull.length != 1) {
+      // Unexpected anyOf shape — treat as nullable object.
+      return FieldSchema(
+        name: name,
+        type: FieldType.object,
+        nullable: true,
+        required: isRequired,
+        defaultValue: defaultValue,
+        title: title,
+        description: description,
+      );
+    }
+
+    final inner = nonNull.first;
+    final hasNull = anyOf.length > nonNull.length;
+
+    // anyOf with $ref → nullable object.
+    if (inner.containsKey(r'$ref')) {
+      final resolved = _resolveRef(inner[r'$ref'] as String, defs);
+      return FieldSchema(
+        name: name,
+        type: FieldType.object,
+        nullable: hasNull,
+        required: isRequired,
+        defaultValue: defaultValue,
+        title: title,
+        description: description,
+        objectSchema: resolved,
+      );
+    }
+
+    // anyOf with type.
+    final innerType = inner['type'] as String?;
+
+    // anyOf with array type (nullable array).
+    if (innerType == 'array') {
+      final itemInfo = _parseArrayItems(inner, defs);
+      return FieldSchema(
+        name: name,
+        type: FieldType.array,
+        nullable: hasNull,
+        required: isRequired,
+        defaultValue: defaultValue,
+        title: title,
+        description: description,
+        itemSchema: itemInfo.objectSchema,
+        itemType: itemInfo.scalarType,
+        nestedItemSchema: itemInfo.nestedItemSchema,
+      );
+    }
+
+    // anyOf with scalar type.
+    final fieldType = _mapType(innerType ?? 'string');
+    final innerFormat = inner['format'] as String? ?? format;
+    return FieldSchema(
+      name: name,
+      type: fieldType,
+      nullable: hasNull,
+      required: isRequired,
+      defaultValue: defaultValue,
+      title: title,
+      description: description,
+      format: innerFormat,
+    );
+  }
+
+  /// Parses a schema with an explicit `type` field.
+  FieldSchema _parseTyped(
+    String name,
+    String type,
+    Map<String, dynamic> schema,
+    Map<String, ObjectSchema> defs, {
+    bool isRequired = false,
+    Object? defaultValue,
+    String? title,
+    String? description,
+    String? format,
+  }) {
+    switch (type) {
+      case 'array':
+        final itemInfo = _parseArrayItems(schema, defs);
+        return FieldSchema(
+          name: name,
+          type: FieldType.array,
+          required: isRequired,
+          defaultValue: defaultValue,
+          title: title,
+          description: description,
+          itemSchema: itemInfo.objectSchema,
+          itemType: itemInfo.scalarType,
+          nestedItemSchema: itemInfo.nestedItemSchema,
+        );
+
+      case 'object':
+        // Check for additionalProperties (map pattern).
+        final additionalProperties = schema['additionalProperties'];
+        if (additionalProperties is Map<String, dynamic>) {
+          final valueInfo = _parseMapValue(additionalProperties, defs);
+          return FieldSchema(
+            name: name,
+            type: FieldType.map,
+            required: isRequired,
+            defaultValue: defaultValue,
+            title: title,
+            description: description,
+            valueType: valueInfo.scalarType,
+            valueObjectSchema: valueInfo.objectSchema,
+          );
+        }
+
+        // Regular nested object with properties.
+        final nested = _parseObject(schema, defs);
+        return FieldSchema(
+          name: name,
+          type: FieldType.object,
+          required: isRequired,
+          defaultValue: defaultValue,
+          title: title,
+          description: description,
+          objectSchema: nested,
+        );
+
+      default:
+        return FieldSchema(
+          name: name,
+          type: _mapType(type),
+          required: isRequired,
+          defaultValue: defaultValue,
+          title: title,
+          description: description,
+          format: format,
+        );
+    }
+  }
+
+  /// Parses array `items` into item type info.
+  _ArrayItemInfo _parseArrayItems(
+    Map<String, dynamic> schema,
+    Map<String, ObjectSchema> defs,
+  ) {
+    final items = schema['items'];
+    if (items == null) {
+      return const _ArrayItemInfo(scalarType: FieldType.object);
+    }
+
+    final itemsMap = items as Map<String, dynamic>;
+
+    // $ref items → object array.
+    if (itemsMap.containsKey(r'$ref')) {
+      final resolved = _resolveRef(itemsMap[r'$ref'] as String, defs);
+      return _ArrayItemInfo(objectSchema: resolved);
+    }
+
+    final itemType = itemsMap['type'] as String?;
+
+    // Nested array (array of arrays).
+    if (itemType == 'array') {
+      final nestedField = _parseField('_nested', itemsMap, defs);
+      return _ArrayItemInfo(nestedItemSchema: nestedField);
+    }
+
+    // Scalar items.
+    if (itemType != null && itemType != 'object') {
+      return _ArrayItemInfo(scalarType: _mapType(itemType));
+    }
+
+    // Inline object items.
+    if (itemsMap.containsKey('properties')) {
+      final objectSchema = _parseObject(itemsMap, defs);
+      return _ArrayItemInfo(objectSchema: objectSchema);
+    }
+
+    return const _ArrayItemInfo(scalarType: FieldType.object);
+  }
+
+  /// Parses `additionalProperties` value schema.
+  _MapValueInfo _parseMapValue(
+    Map<String, dynamic> schema,
+    Map<String, ObjectSchema> defs,
+  ) {
+    if (schema.containsKey(r'$ref')) {
+      final resolved = _resolveRef(schema[r'$ref'] as String, defs);
+      return _MapValueInfo(objectSchema: resolved);
+    }
+
+    final type = schema['type'] as String?;
+    if (type != null) {
+      return _MapValueInfo(scalarType: _mapType(type));
+    }
+
+    return const _MapValueInfo(scalarType: FieldType.object);
+  }
+
+  /// Resolves a `$ref` string like `#/$defs/Citation` to an
+  /// [ObjectSchema].
+  ObjectSchema? _resolveRef(
+    String ref,
+    Map<String, ObjectSchema> defs,
+  ) {
+    // Expected format: "#/$defs/TypeName"
+    final parts = ref.split('/');
+    if (parts.length >= 3 && parts[1] == r'$defs') {
+      return defs[parts[2]];
+    }
+    return null;
+  }
+
+  /// Maps a JSON Schema type string to a [FieldType].
+  FieldType _mapType(String type) {
+    return switch (type) {
+      'string' => FieldType.string,
+      'integer' => FieldType.integer,
+      'number' => FieldType.number,
+      'boolean' => FieldType.boolean,
+      'object' => FieldType.object,
+      'array' => FieldType.array,
+      _ => FieldType.string,
+    };
+  }
+}
+
+/// Internal helper for array item parsing results.
+class _ArrayItemInfo {
+  const _ArrayItemInfo({
+    this.objectSchema,
+    this.scalarType,
+    this.nestedItemSchema,
+  });
+
+  final ObjectSchema? objectSchema;
+  final FieldType? scalarType;
+  final FieldSchema? nestedItemSchema;
+}
+
+/// Internal helper for map value parsing results.
+class _MapValueInfo {
+  const _MapValueInfo({this.objectSchema, this.scalarType});
+
+  final ObjectSchema? objectSchema;
+  final FieldType? scalarType;
+}

--- a/packages/soliplex_schema/lib/src/schema_state_view.dart
+++ b/packages/soliplex_schema/lib/src/schema_state_view.dart
@@ -1,0 +1,217 @@
+import 'package:meta/meta.dart';
+import 'package:soliplex_schema/src/field_schema.dart';
+import 'package:soliplex_schema/src/object_schema.dart';
+
+/// Zero-copy typed wrapper over `Map<String, dynamic>` + [ObjectSchema].
+///
+/// Provides safe, lenient access to AG-UI feature state. Absent fields
+/// return schema defaults, then type defaults (null/empty). Cast
+/// failures are logged and return null — never throws to the widget
+/// layer.
+@immutable
+class SchemaStateView {
+  const SchemaStateView(this._data, this._schema);
+
+  final Map<String, dynamic> _data;
+  final ObjectSchema _schema;
+
+  /// The underlying raw data map.
+  Map<String, dynamic> get rawData => _data;
+
+  /// The schema this view interprets.
+  ObjectSchema get schema => _schema;
+
+  /// Returns the raw value for [field], or `null` if absent.
+  dynamic get(String field) => _data[field];
+
+  /// Whether [field] exists in the underlying data (even if null).
+  bool hasField(String field) => _data.containsKey(field);
+
+  /// All field names present in the underlying data.
+  Iterable<String> get fieldNames => _data.keys;
+
+  /// All field names defined in the schema.
+  Iterable<String> get schemaFieldNames => _schema.fields.keys;
+
+  /// Returns a typed scalar value for [field].
+  ///
+  /// Supports [String], [int], [double], [bool], and [num].
+  /// Returns the schema default if the field is absent, or `null`
+  /// if no default is defined.
+  T? getScalar<T>(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null) {
+      final def = fieldSchema?.defaultValue;
+      if (def == null) return null;
+      return _coerceScalar<T>(def, field);
+    }
+
+    return _coerceScalar<T>(raw, field);
+  }
+
+  /// Returns a nested [SchemaStateView] for [field].
+  ///
+  /// Returns `null` if the field is absent, null, or not a map.
+  SchemaStateView? getObject(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null || raw is! Map<String, dynamic>) return null;
+    final objectSchema = fieldSchema?.objectSchema;
+    if (objectSchema == null) {
+      return SchemaStateView(raw, const ObjectSchema(fields: {}));
+    }
+    return SchemaStateView(raw, objectSchema);
+  }
+
+  /// Returns a list of [SchemaStateView]s for an array-of-objects
+  /// [field].
+  ///
+  /// Returns an empty list if the field is absent, null, or empty.
+  List<SchemaStateView> getObjectList(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null || raw is! List<dynamic>) {
+      return _defaultList(fieldSchema);
+    }
+
+    final itemSchema =
+        fieldSchema?.itemSchema ?? const ObjectSchema(fields: {});
+
+    return raw
+        .whereType<Map<String, dynamic>>()
+        .map((item) => SchemaStateView(item, itemSchema))
+        .toList();
+  }
+
+  /// Returns a typed list of scalars for [field].
+  ///
+  /// Returns an empty list if the field is absent, null, or empty.
+  List<T> getScalarList<T>(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null || raw is! List<dynamic>) {
+      final def = fieldSchema?.defaultValue;
+      if (def is List) {
+        return def.whereType<T>().toList();
+      }
+      return const [];
+    }
+
+    final results = <T>[];
+    for (final item in raw) {
+      final coerced = _coerceScalar<T>(item, field);
+      if (coerced != null) results.add(coerced);
+    }
+    return results;
+  }
+
+  /// Returns a list of lists of [SchemaStateView]s for a nested
+  /// array field (e.g., `List<List<Citation>>`).
+  ///
+  /// Returns an empty list if the field is absent, null, or empty.
+  List<List<SchemaStateView>> getNestedObjectList(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null || raw is! List<dynamic>) return const [];
+
+    final innerField = fieldSchema?.nestedItemSchema;
+    final innerObjectSchema =
+        innerField?.itemSchema ?? const ObjectSchema(fields: {});
+
+    return raw.map<List<SchemaStateView>>((outerItem) {
+      if (outerItem is! List<dynamic>) return const [];
+      return outerItem
+          .whereType<Map<String, dynamic>>()
+          .map((item) => SchemaStateView(item, innerObjectSchema))
+          .toList();
+    }).toList();
+  }
+
+  /// Returns the length of the array at [field], or 0 if absent.
+  int getListLength(String field) {
+    final raw = _data[field];
+    if (raw is List<dynamic>) return raw.length;
+    return 0;
+  }
+
+  /// Returns a typed map for [field] (JSON Schema
+  /// `additionalProperties`).
+  ///
+  /// Returns an empty map if the field is absent, null, or not a
+  /// map.
+  Map<String, T> getMap<T>(String field) {
+    final fieldSchema = _schema[field];
+    final raw = _data[field];
+
+    if (raw == null || raw is! Map<String, dynamic>) {
+      final def = fieldSchema?.defaultValue;
+      if (def is Map<String, dynamic>) {
+        return _coerceMap<T>(def, field);
+      }
+      return const {};
+    }
+
+    return _coerceMap<T>(raw, field);
+  }
+
+  /// Returns the raw list of maps for [field] (useful for
+  /// forwarding to other APIs that expect untyped data).
+  List<Map<String, dynamic>> getRawMapList(String field) {
+    final raw = _data[field];
+    if (raw == null || raw is! List<dynamic>) return const [];
+    return raw.cast<Map<String, dynamic>>();
+  }
+
+  // ================================================================
+  // Private helpers
+  // ================================================================
+
+  List<SchemaStateView> _defaultList(FieldSchema? fieldSchema) {
+    if (fieldSchema?.defaultValue is List) return const [];
+    return const [];
+  }
+
+  T? _coerceScalar<T>(dynamic value, String field) {
+    if (value is T) return value;
+
+    // num → int coercion.
+    if (T == int && value is num) return value.toInt() as T;
+
+    // num → double coercion.
+    if (T == double && value is num) return value.toDouble() as T;
+
+    // String → int tryParse.
+    if (T == int && value is String) {
+      final parsed = int.tryParse(value);
+      if (parsed != null) return parsed as T;
+    }
+
+    // String → double tryParse.
+    if (T == double && value is String) {
+      final parsed = double.tryParse(value);
+      if (parsed != null) return parsed as T;
+    }
+
+    return null;
+  }
+
+  Map<String, T> _coerceMap<T>(
+    Map<String, dynamic> raw,
+    String field,
+  ) {
+    final result = <String, T>{};
+    for (final entry in raw.entries) {
+      final coerced = _coerceScalar<T>(entry.value, field);
+      if (coerced != null) {
+        result[entry.key] = coerced;
+      }
+    }
+    return result;
+  }
+}

--- a/packages/soliplex_schema/pubspec.yaml
+++ b/packages/soliplex_schema/pubspec.yaml
@@ -1,0 +1,14 @@
+name: soliplex_schema
+description: Runtime JSON Schema parsing and typed state views for AG-UI features.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  meta: ^1.9.0
+
+dev_dependencies:
+  test: ^1.24.0
+  very_good_analysis: ^7.0.0

--- a/packages/soliplex_schema/test/schema_parser_test.dart
+++ b/packages/soliplex_schema/test/schema_parser_test.dart
@@ -1,0 +1,464 @@
+import 'package:soliplex_schema/soliplex_schema.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late SchemaParser parser;
+
+  setUp(() {
+    parser = SchemaParser();
+  });
+
+  group('SchemaParser', () {
+    test('parses simple object with scalar fields', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'name': {'type': 'string', 'title': 'Name'},
+          'age': {'type': 'integer'},
+          'score': {'type': 'number', 'default': 0.9},
+          'active': {'type': 'boolean', 'default': true},
+        },
+        'required': ['name'],
+      });
+
+      expect(schema.fields, hasLength(4));
+
+      final name = schema['name']!;
+      expect(name.type, FieldType.string);
+      expect(name.required, isTrue);
+
+      final age = schema['age']!;
+      expect(age.type, FieldType.integer);
+      expect(age.required, isFalse);
+
+      final score = schema['score']!;
+      expect(score.type, FieldType.number);
+      expect(score.defaultValue, 0.9);
+
+      final active = schema['active']!;
+      expect(active.type, FieldType.boolean);
+      expect(active.defaultValue, true);
+    });
+
+    test('parses nullable scalar (anyOf with null)', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'initial_context': {
+            'anyOf': [
+              {'type': 'string'},
+              {'type': 'null'},
+            ],
+            'default': null,
+            'title': 'Initial Context',
+          },
+        },
+      });
+
+      final field = schema['initial_context']!;
+      expect(field.type, FieldType.string);
+      expect(field.nullable, isTrue);
+    });
+
+    test('parses nullable scalar with format', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'last_updated': {
+            'anyOf': [
+              {'format': 'date-time', 'type': 'string'},
+              {'type': 'null'},
+            ],
+            'default': null,
+          },
+        },
+      });
+
+      final field = schema['last_updated']!;
+      expect(field.type, FieldType.string);
+      expect(field.nullable, isTrue);
+      expect(field.format, 'date-time');
+    });
+
+    test('parses scalar array', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'document_filter': {
+            'default': <dynamic>[],
+            'items': {'type': 'string'},
+            'type': 'array',
+          },
+        },
+      });
+
+      final field = schema['document_filter']!;
+      expect(field.type, FieldType.array);
+      expect(field.itemType, FieldType.string);
+      expect(field.itemSchema, isNull);
+    });
+
+    test('parses nullable scalar array (anyOf)', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'headings': {
+            'anyOf': [
+              {
+                'items': {'type': 'string'},
+                'type': 'array',
+              },
+              {'type': 'null'},
+            ],
+            'default': null,
+          },
+        },
+      });
+
+      final field = schema['headings']!;
+      expect(field.type, FieldType.array);
+      expect(field.nullable, isTrue);
+      expect(field.itemType, FieldType.string);
+    });
+
+    test(r'parses object array with $ref', () {
+      final schema = parser.parse({
+        r'$defs': {
+          'Citation': {
+            'type': 'object',
+            'properties': {
+              'document_id': {'type': 'string'},
+              'content': {'type': 'string'},
+            },
+            'required': ['document_id', 'content'],
+          },
+        },
+        'type': 'object',
+        'properties': {
+          'citations': {
+            'default': <dynamic>[],
+            'items': {r'$ref': r'#/$defs/Citation'},
+            'type': 'array',
+          },
+        },
+      });
+
+      final field = schema['citations']!;
+      expect(field.type, FieldType.array);
+      expect(field.itemSchema, isNotNull);
+      expect(field.itemSchema!.fields, hasLength(2));
+      expect(field.itemSchema!['document_id']!.required, isTrue);
+    });
+
+    test(r'parses nullable object (anyOf with $ref)', () {
+      final schema = parser.parse({
+        r'$defs': {
+          'SessionContext': {
+            'type': 'object',
+            'properties': {
+              'summary': {
+                'default': '',
+                'type': 'string',
+              },
+            },
+          },
+        },
+        'type': 'object',
+        'properties': {
+          'session_context': {
+            'anyOf': [
+              {r'$ref': r'#/$defs/SessionContext'},
+              {'type': 'null'},
+            ],
+            'default': null,
+          },
+        },
+      });
+
+      final field = schema['session_context']!;
+      expect(field.type, FieldType.object);
+      expect(field.nullable, isTrue);
+      expect(field.objectSchema, isNotNull);
+      expect(field.objectSchema!['summary']!.defaultValue, '');
+    });
+
+    test('parses additionalProperties (map)', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'properties': {
+          'citation_registry': {
+            'additionalProperties': {'type': 'integer'},
+            'default': <String, dynamic>{},
+            'type': 'object',
+          },
+        },
+      });
+
+      final field = schema['citation_registry']!;
+      expect(field.type, FieldType.map);
+      expect(field.valueType, FieldType.integer);
+    });
+
+    test('parses nested array (array of arrays)', () {
+      final schema = parser.parse({
+        r'$defs': {
+          'Citation': {
+            'type': 'object',
+            'properties': {
+              'content': {'type': 'string'},
+            },
+          },
+        },
+        'type': 'object',
+        'properties': {
+          'citations_history': {
+            'default': <dynamic>[],
+            'items': {
+              'items': {r'$ref': r'#/$defs/Citation'},
+              'type': 'array',
+            },
+            'type': 'array',
+          },
+        },
+      });
+
+      final field = schema['citations_history']!;
+      expect(field.type, FieldType.array);
+      expect(field.nestedItemSchema, isNotNull);
+      expect(field.nestedItemSchema!.type, FieldType.array);
+      expect(field.nestedItemSchema!.itemSchema, isNotNull);
+    });
+
+    test('parses title and description', () {
+      final schema = parser.parse({
+        'type': 'object',
+        'title': 'ChatSessionState',
+        'description': 'State shared between frontend and agent.',
+        'properties': {
+          'field': {'type': 'string', 'title': 'Field Title'},
+        },
+      });
+
+      expect(schema.title, 'ChatSessionState');
+      expect(schema.description, 'State shared between frontend and agent.');
+      expect(schema['field']!.title, 'Field Title');
+    });
+
+    test('handles empty schema gracefully', () {
+      final schema = parser.parse({});
+      expect(schema.fields, isEmpty);
+    });
+
+    test('handles missing properties gracefully', () {
+      final schema = parser.parse({'type': 'object'});
+      expect(schema.fields, isEmpty);
+    });
+  });
+
+  group('SchemaParser with real schema', () {
+    test('parses haiku.rag.chat from schema.json', () {
+      final schema = parser.parse(_haikuRagChatSchema);
+
+      expect(schema.title, 'ChatSessionState');
+      expect(schema.fields, hasLength(7));
+
+      // initial_context: nullable string
+      expect(schema['initial_context']!.type, FieldType.string);
+      expect(schema['initial_context']!.nullable, isTrue);
+
+      // citations: array of Citation objects
+      expect(schema['citations']!.type, FieldType.array);
+      expect(schema['citations']!.itemSchema, isNotNull);
+      expect(
+        schema['citations']!.itemSchema!.fields,
+        hasLength(8),
+      );
+
+      // citations_history: array of arrays of Citations
+      expect(schema['citations_history']!.type, FieldType.array);
+      expect(
+        schema['citations_history']!.nestedItemSchema,
+        isNotNull,
+      );
+
+      // qa_history: array of QAHistoryEntry objects
+      expect(schema['qa_history']!.type, FieldType.array);
+      expect(schema['qa_history']!.itemSchema, isNotNull);
+      expect(
+        schema['qa_history']!.itemSchema!['question']!.required,
+        isTrue,
+      );
+
+      // session_context: nullable SessionContext object
+      expect(schema['session_context']!.type, FieldType.object);
+      expect(schema['session_context']!.nullable, isTrue);
+      expect(schema['session_context']!.objectSchema, isNotNull);
+
+      // document_filter: array of strings
+      expect(schema['document_filter']!.type, FieldType.array);
+      expect(schema['document_filter']!.itemType, FieldType.string);
+
+      // citation_registry: map<string, int>
+      expect(schema['citation_registry']!.type, FieldType.map);
+      expect(
+        schema['citation_registry']!.valueType,
+        FieldType.integer,
+      );
+    });
+  });
+}
+
+/// The haiku.rag.chat schema from schemas/schema.json.
+const _haikuRagChatSchema = <String, dynamic>{
+  r'$defs': {
+    'Citation': {
+      'description': 'Resolved citation with full metadata.',
+      'properties': {
+        'index': {
+          'anyOf': [
+            {'type': 'integer'},
+            {'type': 'null'},
+          ],
+          'default': null,
+          'title': 'Index',
+        },
+        'document_id': {'title': 'Document Id', 'type': 'string'},
+        'chunk_id': {'title': 'Chunk Id', 'type': 'string'},
+        'document_uri': {'title': 'Document Uri', 'type': 'string'},
+        'document_title': {
+          'anyOf': [
+            {'type': 'string'},
+            {'type': 'null'},
+          ],
+          'default': null,
+          'title': 'Document Title',
+        },
+        'page_numbers': {
+          'items': {'type': 'integer'},
+          'title': 'Page Numbers',
+          'type': 'array',
+        },
+        'headings': {
+          'anyOf': [
+            {
+              'items': {'type': 'string'},
+              'type': 'array',
+            },
+            {'type': 'null'},
+          ],
+          'default': null,
+          'title': 'Headings',
+        },
+        'content': {'title': 'Content', 'type': 'string'},
+      },
+      'required': ['document_id', 'chunk_id', 'document_uri', 'content'],
+      'title': 'Citation',
+      'type': 'object',
+    },
+    'QAHistoryEntry': {
+      'description': 'A Q&A pair.',
+      'properties': {
+        'question': {'title': 'Question', 'type': 'string'},
+        'answer': {'title': 'Answer', 'type': 'string'},
+        'confidence': {
+          'default': 0.9,
+          'title': 'Confidence',
+          'type': 'number',
+        },
+        'citations': {
+          'default': <dynamic>[],
+          'items': {r'$ref': r'#/$defs/Citation'},
+          'title': 'Citations',
+          'type': 'array',
+        },
+        'question_embedding': {
+          'anyOf': [
+            {
+              'items': {'type': 'number'},
+              'type': 'array',
+            },
+            {'type': 'null'},
+          ],
+          'default': null,
+          'title': 'Question Embedding',
+        },
+      },
+      'required': ['question', 'answer'],
+      'title': 'QAHistoryEntry',
+      'type': 'object',
+    },
+    'SessionContext': {
+      'description': 'Compressed summary.',
+      'properties': {
+        'summary': {
+          'default': '',
+          'title': 'Summary',
+          'type': 'string',
+        },
+        'last_updated': {
+          'anyOf': [
+            {'format': 'date-time', 'type': 'string'},
+            {'type': 'null'},
+          ],
+          'default': null,
+          'title': 'Last Updated',
+        },
+      },
+      'title': 'SessionContext',
+      'type': 'object',
+    },
+  },
+  'description': 'State shared between frontend and agent via AG-UI.',
+  'properties': {
+    'initial_context': {
+      'anyOf': [
+        {'type': 'string'},
+        {'type': 'null'},
+      ],
+      'default': null,
+      'title': 'Initial Context',
+    },
+    'citations': {
+      'default': <dynamic>[],
+      'items': {r'$ref': r'#/$defs/Citation'},
+      'title': 'Citations',
+      'type': 'array',
+    },
+    'citations_history': {
+      'default': <dynamic>[],
+      'items': {
+        'items': {r'$ref': r'#/$defs/Citation'},
+        'type': 'array',
+      },
+      'title': 'Citations History',
+      'type': 'array',
+    },
+    'qa_history': {
+      'default': <dynamic>[],
+      'items': {r'$ref': r'#/$defs/QAHistoryEntry'},
+      'title': 'Qa History',
+      'type': 'array',
+    },
+    'session_context': {
+      'anyOf': [
+        {r'$ref': r'#/$defs/SessionContext'},
+        {'type': 'null'},
+      ],
+      'default': null,
+    },
+    'document_filter': {
+      'default': <dynamic>[],
+      'items': {'type': 'string'},
+      'title': 'Document Filter',
+      'type': 'array',
+    },
+    'citation_registry': {
+      'additionalProperties': {'type': 'integer'},
+      'default': <String, dynamic>{},
+      'title': 'Citation Registry',
+      'type': 'object',
+    },
+  },
+  'title': 'ChatSessionState',
+  'type': 'object',
+};


### PR DESCRIPTION
## Summary
- Add `soliplex_schema` package: pure Dart feature schema parsing, registry, and state views

## Changes
- **FeatureSchema / FieldSchema / ObjectSchema**: Domain models for schema definitions
- **SchemaParser**: Parses schema definitions into typed models
- **FeatureSchemaRegistry**: Registry for managing feature schemas
- **SchemaStateView**: Typed view over schema state data

## Test plan
- [x] `dart test` in soliplex_schema — parser tests pass
- [x] `dart analyze` soliplex_schema — no issues
- [x] `dart format .` — no changes needed