### PR TITLE
feat(monty): implement M13 async/futures in DefaultMontyBridge

### DIFF
--- a/packages/soliplex_interpreter_monty/docs/monty_constraints.md
+++ b/packages/soliplex_interpreter_monty/docs/monty_constraints.md
@@ -11,7 +11,7 @@ functions or LLM system prompts.
 | No `import` | All capabilities come from registered host functions |
 | No `class` | Flat procedural code only — dicts, lists, strings, host function returns |
 | No I/O | No file, network, or system calls |
-| No `async`/`await` | Synchronous execution only (M13 future) |
+| `async`/`await` | Supported when platform implements `MontyFutureCapable` |
 
 ## Supported Control Flow
 
@@ -50,8 +50,8 @@ Only JSON-serializable types cross the Python-Dart boundary:
 | Handler errors | Dart handler exceptions → `resumeWithError()` → Python sees error |
 | Unknown functions | Calls to unregistered functions → `resumeWithError()` |
 | Concurrency | Single execution at a time per bridge instance |
+| Async host functions | Host function futures launched immediately, resolved on `MontyResolveFutures` |
 
 ## Future Work
 
-- **M13:** Async/await support (`MontyResolveFutures` handling)
 - **S10:** `MontySession` for persistent state across executions

--- a/packages/soliplex_schema/test/feature_schema_registry_test.dart
+++ b/packages/soliplex_schema/test/feature_schema_registry_test.dart
@@ -1,0 +1,197 @@
+import 'package:soliplex_schema/soliplex_schema.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late FeatureSchemaRegistry registry;
+
+  setUp(() {
+    registry = FeatureSchemaRegistry();
+  });
+
+  group('FeatureSchemaRegistry', () {
+    test('register and retrieve schema', () {
+      registry.register('room-1', {
+        'haiku.rag.chat': {
+          'name': 'haiku.rag.chat',
+          'description': 'Chat state',
+          'source': 'SERVER',
+          'json_schema': {
+            'type': 'object',
+            'properties': {
+              'summary': {'type': 'string', 'default': ''},
+            },
+          },
+        },
+      });
+
+      expect(registry.hasRoom('room-1'), isTrue);
+      expect(registry.hasRoom('room-2'), isFalse);
+
+      final schema = registry.getSchema('room-1', 'haiku.rag.chat');
+      expect(schema, isNotNull);
+      expect(schema!.name, 'haiku.rag.chat');
+      expect(schema.description, 'Chat state');
+      expect(schema.source, FeatureSource.server);
+      expect(schema.objectSchema['summary'], isNotNull);
+    });
+
+    test('getSchemas returns all features for room', () {
+      registry.register('room-1', {
+        'feature_a': {
+          'name': 'feature_a',
+          'description': 'A',
+          'source': 'CLIENT',
+          'json_schema': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          },
+        },
+        'feature_b': {
+          'name': 'feature_b',
+          'description': 'B',
+          'source': 'EITHER',
+          'json_schema': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          },
+        },
+      });
+
+      final schemas = registry.getSchemas('room-1');
+      expect(schemas, hasLength(2));
+      expect(schemas.keys, containsAll(['feature_a', 'feature_b']));
+    });
+
+    test('returns null for unregistered room/feature', () {
+      expect(registry.getSchema('room-1', 'missing'), isNull);
+      expect(registry.getSchemas('room-1'), isEmpty);
+    });
+
+    test('viewFor creates SchemaStateView', () {
+      registry.register('room-1', {
+        'my_feature': {
+          'name': 'my_feature',
+          'description': 'Test',
+          'source': 'SERVER',
+          'json_schema': {
+            'type': 'object',
+            'properties': {
+              'value': {'type': 'string'},
+            },
+          },
+        },
+      });
+
+      final aguiState = <String, dynamic>{
+        'my_feature': {'value': 'hello'},
+      };
+
+      final view = registry.viewFor('room-1', 'my_feature', aguiState);
+      expect(view, isNotNull);
+      expect(view!.getScalar<String>('value'), 'hello');
+    });
+
+    test('viewFor returns null for missing feature in state', () {
+      registry.register('room-1', {
+        'my_feature': {
+          'name': 'my_feature',
+          'description': 'Test',
+          'source': 'SERVER',
+          'json_schema': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          },
+        },
+      });
+
+      final view = registry.viewFor(
+        'room-1',
+        'my_feature',
+        const <String, dynamic>{},
+      );
+      expect(view, isNull);
+    });
+
+    test('viewFor returns null for unregistered feature', () {
+      final view = registry.viewFor(
+        'room-1',
+        'missing',
+        const <String, dynamic>{},
+      );
+      expect(view, isNull);
+    });
+
+    test('evict removes room', () {
+      registry.register('room-1', {
+        'f': {
+          'name': 'f',
+          'description': '',
+          'source': 'SERVER',
+          'json_schema': {
+            'type': 'object',
+            'properties': <String, dynamic>{},
+          },
+        },
+      });
+
+      expect(registry.hasRoom('room-1'), isTrue);
+      registry.evict('room-1');
+      expect(registry.hasRoom('room-1'), isFalse);
+    });
+
+    test('clear removes all rooms', () {
+      registry
+        ..register('room-1', {
+          'f': {
+            'name': 'f',
+            'description': '',
+            'source': 'SERVER',
+            'json_schema': {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+            },
+          },
+        })
+        ..register('room-2', {
+          'g': {
+            'name': 'g',
+            'description': '',
+            'source': 'CLIENT',
+            'json_schema': {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+            },
+          },
+        })
+        ..clear();
+      expect(registry.hasRoom('room-1'), isFalse);
+      expect(registry.hasRoom('room-2'), isFalse);
+    });
+
+    test('FeatureSource.fromString parses values', () {
+      expect(FeatureSource.fromString('CLIENT'), FeatureSource.client);
+      expect(FeatureSource.fromString('SERVER'), FeatureSource.server);
+      expect(FeatureSource.fromString('EITHER'), FeatureSource.either);
+      expect(FeatureSource.fromString('client'), FeatureSource.client);
+      expect(
+        FeatureSource.fromString('unknown'),
+        FeatureSource.either,
+      );
+    });
+
+    test('viewFromSchema creates view directly', () {
+      final schema = SchemaParser().parse({
+        'type': 'object',
+        'properties': {
+          'x': {'type': 'integer'},
+        },
+      });
+
+      final view = FeatureSchemaRegistry.viewFromSchema(
+        {'x': 42},
+        schema,
+      );
+      expect(view.getScalar<int>('x'), 42);
+    });
+  });
+}

--- a/packages/soliplex_schema/test/schema_state_view_test.dart
+++ b/packages/soliplex_schema/test/schema_state_view_test.dart
@@ -1,0 +1,680 @@
+import 'package:soliplex_schema/soliplex_schema.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late SchemaParser parser;
+
+  setUp(() {
+    parser = SchemaParser();
+  });
+
+  group('SchemaStateView', () {
+    group('scalars', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+            'count': {'type': 'integer', 'default': 0},
+            'score': {'type': 'number', 'default': 0.9},
+            'active': {'type': 'boolean', 'default': true},
+            'nullable_name': {
+              'anyOf': [
+                {'type': 'string'},
+                {'type': 'null'},
+              ],
+              'default': null,
+            },
+          },
+          'required': ['name'],
+        });
+      });
+
+      test('returns value when present', () {
+        final view = SchemaStateView(
+          const {'name': 'test', 'count': 5, 'score': 1.5, 'active': false},
+          schema,
+        );
+
+        expect(view.getScalar<String>('name'), 'test');
+        expect(view.getScalar<int>('count'), 5);
+        expect(view.getScalar<double>('score'), 1.5);
+        expect(view.getScalar<bool>('active'), isFalse);
+      });
+
+      test('returns schema default when absent', () {
+        final view = SchemaStateView(const {'name': 'test'}, schema);
+
+        expect(view.getScalar<int>('count'), 0);
+        expect(view.getScalar<double>('score'), 0.9);
+        expect(view.getScalar<bool>('active'), isTrue);
+      });
+
+      test('returns null when absent with no default', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getScalar<String>('name'), isNull);
+      });
+
+      test('returns null for nullable absent field', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getScalar<String>('nullable_name'), isNull);
+      });
+
+      test('coerces num to int', () {
+        final view = SchemaStateView(const {'count': 5.0}, schema);
+        expect(view.getScalar<int>('count'), 5);
+      });
+
+      test('coerces num to double', () {
+        final view = SchemaStateView(const {'score': 2}, schema);
+        expect(view.getScalar<double>('score'), 2.0);
+      });
+
+      test('coerces string to int via tryParse', () {
+        final view = SchemaStateView(const {'count': '42'}, schema);
+        expect(view.getScalar<int>('count'), 42);
+      });
+
+      test('returns null for non-parseable string', () {
+        final view = SchemaStateView(const {'count': 'not-a-number'}, schema);
+        expect(view.getScalar<int>('count'), isNull);
+      });
+    });
+
+    group('objects', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          r'$defs': {
+            'Inner': {
+              'type': 'object',
+              'properties': {
+                'value': {'type': 'string', 'default': ''},
+              },
+            },
+          },
+          'type': 'object',
+          'properties': {
+            'nested': {
+              'anyOf': [
+                {r'$ref': r'#/$defs/Inner'},
+                {'type': 'null'},
+              ],
+              'default': null,
+            },
+          },
+        });
+      });
+
+      test('returns view when present', () {
+        final view = SchemaStateView(
+          const {
+            'nested': {'value': 'hello'},
+          },
+          schema,
+        );
+        final nested = view.getObject('nested');
+        expect(nested, isNotNull);
+        expect(nested!.getScalar<String>('value'), 'hello');
+      });
+
+      test('returns null when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getObject('nested'), isNull);
+      });
+
+      test('returns null when null in data', () {
+        final view = SchemaStateView(const {'nested': null}, schema);
+        expect(view.getObject('nested'), isNull);
+      });
+    });
+
+    group('object lists', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          r'$defs': {
+            'Item': {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'string'},
+                'count': {'type': 'integer', 'default': 0},
+              },
+              'required': ['id'],
+            },
+          },
+          'type': 'object',
+          'properties': {
+            'items': {
+              'default': <dynamic>[],
+              'items': {r'$ref': r'#/$defs/Item'},
+              'type': 'array',
+            },
+          },
+        });
+      });
+
+      test('returns typed views', () {
+        final view = SchemaStateView(
+          const {
+            'items': [
+              {'id': 'a', 'count': 1},
+              {'id': 'b'},
+            ],
+          },
+          schema,
+        );
+
+        final items = view.getObjectList('items');
+        expect(items, hasLength(2));
+        expect(items[0].getScalar<String>('id'), 'a');
+        expect(items[0].getScalar<int>('count'), 1);
+        expect(items[1].getScalar<String>('id'), 'b');
+        expect(items[1].getScalar<int>('count'), 0); // default
+      });
+
+      test('returns empty list when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getObjectList('items'), isEmpty);
+      });
+
+      test('returns list length', () {
+        final view = SchemaStateView(
+          const {
+            'items': [
+              {'id': 'a'},
+              {'id': 'b'},
+              {'id': 'c'},
+            ],
+          },
+          schema,
+        );
+        expect(view.getListLength('items'), 3);
+      });
+
+      test('returns 0 length when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getListLength('items'), 0);
+      });
+    });
+
+    group('scalar lists', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          'type': 'object',
+          'properties': {
+            'tags': {
+              'default': <dynamic>[],
+              'items': {'type': 'string'},
+              'type': 'array',
+            },
+            'numbers': {
+              'items': {'type': 'integer'},
+              'type': 'array',
+            },
+          },
+        });
+      });
+
+      test('returns typed scalars', () {
+        final view = SchemaStateView(
+          const {
+            'tags': ['a', 'b'],
+            'numbers': [1, 2, 3],
+          },
+          schema,
+        );
+
+        expect(view.getScalarList<String>('tags'), ['a', 'b']);
+        expect(view.getScalarList<int>('numbers'), [1, 2, 3]);
+      });
+
+      test('returns empty list when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getScalarList<String>('tags'), isEmpty);
+      });
+
+      test('coerces num items to int', () {
+        final view = SchemaStateView(
+          const {
+            'numbers': [1.0, 2.0],
+          },
+          schema,
+        );
+        expect(view.getScalarList<int>('numbers'), [1, 2]);
+      });
+    });
+
+    group('nested object lists', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          r'$defs': {
+            'Citation': {
+              'type': 'object',
+              'properties': {
+                'content': {'type': 'string'},
+              },
+            },
+          },
+          'type': 'object',
+          'properties': {
+            'citations_history': {
+              'default': <dynamic>[],
+              'items': {
+                'items': {r'$ref': r'#/$defs/Citation'},
+                'type': 'array',
+              },
+              'type': 'array',
+            },
+          },
+        });
+      });
+
+      test('returns nested list of views', () {
+        final view = SchemaStateView(
+          const {
+            'citations_history': [
+              [
+                {'content': 'first'},
+              ],
+              [
+                {'content': 'second'},
+                {'content': 'third'},
+              ],
+            ],
+          },
+          schema,
+        );
+
+        final history = view.getNestedObjectList('citations_history');
+        expect(history, hasLength(2));
+        expect(history[0], hasLength(1));
+        expect(history[0][0].getScalar<String>('content'), 'first');
+        expect(history[1], hasLength(2));
+        expect(
+          history[1][1].getScalar<String>('content'),
+          'third',
+        );
+      });
+
+      test('returns empty list when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(
+          view.getNestedObjectList('citations_history'),
+          isEmpty,
+        );
+      });
+    });
+
+    group('maps', () {
+      late ObjectSchema schema;
+
+      setUp(() {
+        schema = parser.parse({
+          'type': 'object',
+          'properties': {
+            'registry': {
+              'additionalProperties': {'type': 'integer'},
+              'default': <String, dynamic>{},
+              'type': 'object',
+            },
+          },
+        });
+      });
+
+      test('returns typed map', () {
+        final view = SchemaStateView(
+          const {
+            'registry': {'a': 1, 'b': 2},
+          },
+          schema,
+        );
+
+        final registry = view.getMap<int>('registry');
+        expect(registry, {'a': 1, 'b': 2});
+      });
+
+      test('returns empty map when absent', () {
+        final view = SchemaStateView(const {}, schema);
+        expect(view.getMap<int>('registry'), isEmpty);
+      });
+
+      test('coerces num values to int', () {
+        final view = SchemaStateView(
+          const {
+            'registry': {'a': 1.0},
+          },
+          schema,
+        );
+        expect(view.getMap<int>('registry'), {'a': 1});
+      });
+    });
+
+    group('raw access', () {
+      test('get returns raw value', () {
+        const view = SchemaStateView(
+          {'key': 'value'},
+          ObjectSchema(fields: {}),
+        );
+        expect(view.get('key'), 'value');
+        expect(view.get('missing'), isNull);
+      });
+
+      test('hasField checks presence', () {
+        const view = SchemaStateView(
+          {'key': null},
+          ObjectSchema(fields: {}),
+        );
+        expect(view.hasField('key'), isTrue);
+        expect(view.hasField('missing'), isFalse);
+      });
+
+      test('fieldNames returns data keys', () {
+        const view = SchemaStateView(
+          {'a': 1, 'b': 2},
+          ObjectSchema(fields: {}),
+        );
+        expect(view.fieldNames, containsAll(['a', 'b']));
+      });
+
+      test('getRawMapList returns untyped maps', () {
+        const view = SchemaStateView(
+          {
+            'items': [
+              {'id': 'a'},
+              {'id': 'b'},
+            ],
+          },
+          ObjectSchema(fields: {}),
+        );
+        expect(view.getRawMapList('items'), hasLength(2));
+        expect(view.getRawMapList('missing'), isEmpty);
+      });
+    });
+  });
+
+  group('golden: haiku.rag.chat parity', () {
+    late ObjectSchema schema;
+    late SchemaStateView view;
+
+    setUp(() {
+      schema = parser.parse(_haikuRagChatSchema);
+      view = SchemaStateView(_haikuRagChatData, schema);
+    });
+
+    test('initial_context', () {
+      expect(view.getScalar<String>('initial_context'), isNull);
+    });
+
+    test('citations list', () {
+      final citations = view.getObjectList('citations');
+      expect(citations, hasLength(1));
+      expect(
+        citations[0].getScalar<String>('document_id'),
+        'doc-1',
+      );
+      expect(citations[0].getScalar<String>('content'), 'Some text');
+      expect(citations[0].getScalar<int>('index'), isNull);
+      expect(
+        citations[0].getScalar<String>('document_title'),
+        'My Doc',
+      );
+      expect(
+        citations[0].getScalarList<int>('page_numbers'),
+        [1, 2],
+      );
+      expect(
+        citations[0].getScalarList<String>('headings'),
+        ['Chapter 1'],
+      );
+    });
+
+    test('citations length', () {
+      expect(view.getListLength('citations'), 1);
+    });
+
+    test('qa_history with nested citations', () {
+      final qaHistory = view.getObjectList('qa_history');
+      expect(qaHistory, hasLength(1));
+
+      final entry = qaHistory[0];
+      expect(entry.getScalar<String>('question'), 'What is this?');
+      expect(entry.getScalar<String>('answer'), 'It is a test.');
+      expect(entry.getScalar<double>('confidence'), 0.95);
+
+      final citations = entry.getObjectList('citations');
+      expect(citations, hasLength(1));
+      expect(
+        citations[0].getScalar<String>('document_id'),
+        'doc-1',
+      );
+    });
+
+    test('session_context nullable object', () {
+      final session = view.getObject('session_context');
+      expect(session, isNotNull);
+      expect(session!.getScalar<String>('summary'), 'A summary');
+      expect(
+        session.getScalar<String>('last_updated'),
+        '2024-01-01T00:00:00Z',
+      );
+    });
+
+    test('document_filter scalar list', () {
+      expect(
+        view.getScalarList<String>('document_filter'),
+        ['doc-1'],
+      );
+    });
+
+    test('citation_registry map', () {
+      expect(
+        view.getMap<int>('citation_registry'),
+        {'cite-1': 0},
+      );
+    });
+
+    test('citations_history nested list', () {
+      final history = view.getNestedObjectList('citations_history');
+      expect(history, hasLength(1));
+      expect(history[0], hasLength(1));
+      expect(
+        history[0][0].getScalar<String>('content'),
+        'Some text',
+      );
+    });
+
+    test('absent field returns schema default', () {
+      final emptyView = SchemaStateView(const {}, schema);
+      expect(emptyView.getScalar<String>('initial_context'), isNull);
+      expect(emptyView.getObjectList('citations'), isEmpty);
+      expect(emptyView.getObjectList('qa_history'), isEmpty);
+      expect(
+        emptyView.getScalarList<String>('document_filter'),
+        isEmpty,
+      );
+      expect(emptyView.getMap<int>('citation_registry'), isEmpty);
+      expect(emptyView.getObject('session_context'), isNull);
+    });
+  });
+}
+
+const _haikuRagChatSchema = <String, dynamic>{
+  r'$defs': {
+    'Citation': {
+      'properties': {
+        'index': {
+          'anyOf': [
+            {'type': 'integer'},
+            {'type': 'null'},
+          ],
+          'default': null,
+        },
+        'document_id': {'type': 'string'},
+        'chunk_id': {'type': 'string'},
+        'document_uri': {'type': 'string'},
+        'document_title': {
+          'anyOf': [
+            {'type': 'string'},
+            {'type': 'null'},
+          ],
+          'default': null,
+        },
+        'page_numbers': {
+          'items': {'type': 'integer'},
+          'type': 'array',
+        },
+        'headings': {
+          'anyOf': [
+            {
+              'items': {'type': 'string'},
+              'type': 'array',
+            },
+            {'type': 'null'},
+          ],
+          'default': null,
+        },
+        'content': {'type': 'string'},
+      },
+      'required': ['document_id', 'chunk_id', 'document_uri', 'content'],
+      'type': 'object',
+    },
+    'QAHistoryEntry': {
+      'properties': {
+        'question': {'type': 'string'},
+        'answer': {'type': 'string'},
+        'confidence': {'default': 0.9, 'type': 'number'},
+        'citations': {
+          'default': <dynamic>[],
+          'items': {r'$ref': r'#/$defs/Citation'},
+          'type': 'array',
+        },
+        'question_embedding': {
+          'anyOf': [
+            {
+              'items': {'type': 'number'},
+              'type': 'array',
+            },
+            {'type': 'null'},
+          ],
+          'default': null,
+        },
+      },
+      'required': ['question', 'answer'],
+      'type': 'object',
+    },
+    'SessionContext': {
+      'properties': {
+        'summary': {'default': '', 'type': 'string'},
+        'last_updated': {
+          'anyOf': [
+            {'format': 'date-time', 'type': 'string'},
+            {'type': 'null'},
+          ],
+          'default': null,
+        },
+      },
+      'type': 'object',
+    },
+  },
+  'type': 'object',
+  'properties': {
+    'initial_context': {
+      'anyOf': [
+        {'type': 'string'},
+        {'type': 'null'},
+      ],
+      'default': null,
+    },
+    'citations': {
+      'default': <dynamic>[],
+      'items': {r'$ref': r'#/$defs/Citation'},
+      'type': 'array',
+    },
+    'citations_history': {
+      'default': <dynamic>[],
+      'items': {
+        'items': {r'$ref': r'#/$defs/Citation'},
+        'type': 'array',
+      },
+      'type': 'array',
+    },
+    'qa_history': {
+      'default': <dynamic>[],
+      'items': {r'$ref': r'#/$defs/QAHistoryEntry'},
+      'type': 'array',
+    },
+    'session_context': {
+      'anyOf': [
+        {r'$ref': r'#/$defs/SessionContext'},
+        {'type': 'null'},
+      ],
+      'default': null,
+    },
+    'document_filter': {
+      'default': <dynamic>[],
+      'items': {'type': 'string'},
+      'type': 'array',
+    },
+    'citation_registry': {
+      'additionalProperties': {'type': 'integer'},
+      'default': <String, dynamic>{},
+      'type': 'object',
+    },
+  },
+  'title': 'ChatSessionState',
+};
+
+const _haikuRagChatData = <String, dynamic>{
+  'initial_context': null,
+  'citations': [
+    {
+      'document_id': 'doc-1',
+      'chunk_id': 'chunk-1',
+      'document_uri': 'https://example.com/doc.pdf',
+      'document_title': 'My Doc',
+      'content': 'Some text',
+      'page_numbers': [1, 2],
+      'headings': ['Chapter 1'],
+    },
+  ],
+  'citations_history': [
+    [
+      {
+        'document_id': 'doc-1',
+        'chunk_id': 'chunk-1',
+        'document_uri': 'https://example.com/doc.pdf',
+        'content': 'Some text',
+      },
+    ],
+  ],
+  'qa_history': [
+    {
+      'question': 'What is this?',
+      'answer': 'It is a test.',
+      'confidence': 0.95,
+      'citations': [
+        {
+          'document_id': 'doc-1',
+          'chunk_id': 'chunk-1',
+          'document_uri': 'https://example.com/doc.pdf',
+          'content': 'Some text',
+        },
+      ],
+    },
+  ],
+  'session_context': {
+    'summary': 'A summary',
+    'last_updated': '2024-01-01T00:00:00Z',
+  },
+  'document_filter': ['doc-1'],
+  'citation_registry': {'cite-1': 0},
+};


### PR DESCRIPTION
## Summary
- Add async/futures support to `DefaultMontyBridge` so Python `async`/`await` and `asyncio.gather` work when the platform implements `MontyFutureCapable`
- Host function handlers launch immediately as futures via `resumeAsFuture()`, resolved concurrently when `MontyResolveFutures` arrives
- Falls back to existing sync behavior on platforms that don't implement `MontyFutureCapable`

## Changes
- **`default_monty_bridge.dart`**: Add `_PendingFuture` tracking type, `_dispatchToolCallAsFuture()`, `_resolveFutures()`, modify `_handlePending()` and `_run()` for futures routing
- **`default_monty_bridge_test.dart`**: Update 3 existing tests for futures path, add 7 new M13 tests, add `_SyncOnlyMockPlatform` helper
- **`monty_constraints.md`**: async/await supported, M13 struck from future work
- **`soliplex_schema` tests**: Fix pre-existing lint issues (const literals, cascades)

## Test plan
- [x] 22/22 bridge tests pass (`dart test`)
- [x] `dart format . --set-exit-if-changed` clean
- [x] `dart analyze --fatal-infos` clean (monty package)
- [x] Pre-commit hooks pass