### PR TITLE
refactor(tui): remove direct soliplex_client dependency

### DIFF
--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -5,6 +5,28 @@
 /// `soliplex_logging` — no Flutter imports allowed.
 library;
 
+// Re-export client types so consumers only depend on soliplex_agent.
+// Hide HTTP/auth/util internals — consumers use createClientBundle() instead.
+export 'package:soliplex_client/soliplex_client.dart'
+    hide
+        AuthenticatedHttpClient,
+        DartHttpClient,
+        HttpClientAdapter,
+        HttpObserver,
+        HttpResponse,
+        HttpTransport,
+        ObservableHttpClient,
+        OidcDiscoveryDocument,
+        RefreshingHttpClient,
+        SoliplexHttpClient,
+        TokenRefreshFailure,
+        TokenRefreshResult,
+        TokenRefreshService,
+        TokenRefreshSuccess,
+        TokenRefresher,
+        UrlBuilder;
+
+export 'src/client_bundle.dart';
 export 'src/host/fake_host_api.dart';
 export 'src/host/host_api.dart';
 export 'src/host/native_platform_constraints.dart';

--- a/packages/soliplex_agent/lib/src/client_bundle.dart
+++ b/packages/soliplex_agent/lib/src/client_bundle.dart
@@ -1,0 +1,41 @@
+import 'package:soliplex_client/soliplex_client.dart';
+
+/// Pre-wired API + AG-UI client bundle.
+///
+/// Returned by [createClientBundle]. Call `close` when done.
+typedef ClientBundle = ({
+  SoliplexApi api,
+  AgUiClient agUiClient,
+  Future<void> Function() close,
+});
+
+/// Creates a [ClientBundle] from a server URL.
+///
+/// Wires up HTTP transport, URL builder, and AG-UI client so that
+/// consumers only need a server URL — no knowledge of HTTP internals.
+ClientBundle createClientBundle(String serverUrl) {
+  final baseUrl = '$serverUrl/api/v1';
+
+  final apiHttpClient = DartHttpClient();
+  final sseHttpClient = DartHttpClient();
+
+  final transport = HttpTransport(client: apiHttpClient);
+  final urlBuilder = UrlBuilder(baseUrl);
+
+  final api = SoliplexApi(transport: transport, urlBuilder: urlBuilder);
+  final agUiClient = AgUiClient(
+    config: AgUiClientConfig(baseUrl: baseUrl),
+    httpClient: HttpClientAdapter(client: sseHttpClient),
+  );
+
+  return (
+    api: api,
+    agUiClient: agUiClient,
+    close: () async {
+      await agUiClient.close();
+      api.close();
+      apiHttpClient.close();
+      sseHttpClient.close();
+    },
+  );
+}

--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -4,43 +4,12 @@ import 'dart:io';
 import 'package:nocterm/nocterm.dart';
 import 'package:nocterm_bloc/nocterm_bloc.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 
 import 'package:soliplex_tui/src/components/chat_page.dart';
 import 'package:soliplex_tui/src/file_sink.dart';
 import 'package:soliplex_tui/src/loggers.dart';
 import 'package:soliplex_tui/src/state/tui_chat_cubit.dart';
-
-/// Shared infrastructure stack used by both [launchTui] and [runHeadless].
-typedef _Stack = ({
-  SoliplexApi api,
-  AgUiClient agUiClient,
-  Future<void> Function() close,
-});
-
-/// Builds the HTTP client, API, and AgUiClient.
-_Stack _buildStack(String serverUrl) {
-  final httpClient = DartHttpClient();
-  final transport = HttpTransport(client: httpClient);
-  final urlBuilder = UrlBuilder('$serverUrl/api/v1');
-  final api = SoliplexApi(transport: transport, urlBuilder: urlBuilder);
-
-  final adapter = HttpClientAdapter(client: httpClient);
-  final agUiClient = AgUiClient(
-    config: AgUiClientConfig(baseUrl: '$serverUrl/api/v1'),
-    httpClient: adapter,
-  );
-
-  return (
-    api: api,
-    agUiClient: agUiClient,
-    close: () async {
-      await agUiClient.close();
-      api.close();
-    },
-  );
-}
 
 /// Launches the Soliplex TUI application.
 ///
@@ -60,7 +29,7 @@ Future<void> launchTui({
 
   Loggers.app.info('Starting TUI, server=$serverUrl, logFile=$logFile');
 
-  final stack = _buildStack(serverUrl);
+  final stack = createClientBundle(serverUrl);
 
   try {
     // Resolve room.
@@ -134,7 +103,7 @@ Future<void> runHeadless({
     'Starting headless mode, server=$serverUrl, logFile=$logFile',
   );
 
-  final stack = _buildStack(serverUrl);
+  final stack = createClientBundle(serverUrl);
   AgentRuntime? runtime;
 
   try {
@@ -189,7 +158,7 @@ Future<void> runHeadless({
 Future<void> listRooms({
   required String serverUrl,
 }) async {
-  final stack = _buildStack(serverUrl);
+  final stack = createClientBundle(serverUrl);
   try {
     final rooms = await stack.api.getRooms();
     for (final room in rooms) {

--- a/packages/soliplex_tui/lib/src/components/chat_body.dart
+++ b/packages/soliplex_tui/lib/src/components/chat_body.dart
@@ -1,6 +1,6 @@
 import 'package:nocterm/nocterm.dart';
 import 'package:nocterm_bloc/nocterm_bloc.dart';
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_tui/src/components/message_item.dart';
 import 'package:soliplex_tui/src/state/tui_chat_cubit.dart';

--- a/packages/soliplex_tui/lib/src/components/message_item.dart
+++ b/packages/soliplex_tui/lib/src/components/message_item.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Renders a single chat message based on its subtype.
 class MessageItem extends StatelessComponent {

--- a/packages/soliplex_tui/lib/src/components/tool_status_bar.dart
+++ b/packages/soliplex_tui/lib/src/components/tool_status_bar.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Status bar shown while client-side tools are executing.
 class ToolStatusBar extends StatelessComponent {

--- a/packages/soliplex_tui/lib/src/state/tui_chat_cubit.dart
+++ b/packages/soliplex_tui/lib/src/state/tui_chat_cubit.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart';
 
 import 'package:soliplex_tui/src/loggers.dart';
 import 'package:soliplex_tui/src/state/tui_chat_state.dart';

--- a/packages/soliplex_tui/lib/src/state/tui_chat_state.dart
+++ b/packages/soliplex_tui/lib/src/state/tui_chat_state.dart
@@ -1,4 +1,4 @@
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Chat state for the TUI.
 ///

--- a/packages/soliplex_tui/pubspec.yaml
+++ b/packages/soliplex_tui/pubspec.yaml
@@ -14,8 +14,6 @@ dependencies:
   nocterm_bloc: ^1.0.0
   soliplex_agent:
     path: ../soliplex_agent
-  soliplex_client:
-    path: ../soliplex_client
   soliplex_logging:
     path: ../soliplex_logging
 

--- a/packages/soliplex_tui/test/helpers/fake_event_stream.dart
+++ b/packages/soliplex_tui/test/helpers/fake_event_stream.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 /// Builds a mock AG-UI event stream from a list of events.
 ///

--- a/packages/soliplex_tui/test/helpers/test_helpers.dart
+++ b/packages/soliplex_tui/test/helpers/test_helpers.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 

--- a/packages/soliplex_tui/test/src/headless_test.dart
+++ b/packages/soliplex_tui/test/src/headless_test.dart
@@ -1,5 +1,5 @@
 import 'package:mocktail/mocktail.dart';
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:test/test.dart';
 
 import '../helpers/test_helpers.dart';

--- a/packages/soliplex_tui/test/state/tui_chat_cubit_test.dart
+++ b/packages/soliplex_tui/test/state/tui_chat_cubit_test.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_tui/src/state/tui_chat_cubit.dart';
 import 'package:soliplex_tui/src/state/tui_chat_state.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_tui/test/state/tui_chat_state_test.dart
+++ b/packages/soliplex_tui/test/state/tui_chat_state_test.dart
@@ -1,4 +1,4 @@
-import 'package:soliplex_client/soliplex_client.dart';
+import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_tui/src/state/tui_chat_state.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## Summary
- Remove `soliplex_client` as a direct dependency of `soliplex_tui` — consumers now depend on `soliplex_agent` only
- Add `createClientBundle()` factory to `soliplex_agent` that encapsulates HTTP stack wiring
- Re-export `soliplex_client` types from `soliplex_agent` barrel with `hide` for 16 HTTP/auth/util internals

## Changes
- **soliplex_agent**: New `ClientBundle` typedef + `createClientBundle(serverUrl)` factory in `src/client_bundle.dart`
- **soliplex_agent**: Barrel re-exports `soliplex_client` with `hide` for `DartHttpClient`, `HttpTransport`, `UrlBuilder`, `HttpClientAdapter`, auth types, etc.
- **soliplex_tui/app.dart**: Replaced `_Stack` typedef + `_buildStack()` with `createClientBundle()` (also fixes latent bug: now uses separate HTTP clients for REST vs SSE)
- **soliplex_tui**: Updated 11 files (6 lib + 5 test) to import from `soliplex_agent` instead of `soliplex_client`
- **soliplex_tui/pubspec.yaml**: Removed `soliplex_client` direct dependency (remains transitive via `soliplex_agent`)

## Test plan
- [x] `dart analyze --fatal-infos` — 0 issues (soliplex_tui)
- [x] `dart test` — 21/21 pass (soliplex_tui)
- [x] `dart test` — 189/189 pass (soliplex_agent)
- [x] `dart format --set-exit-if-changed .` — no changes
- [x] `grep -r 'soliplex_client'` — only in PLAN.md and 1 doc comment (no imports)