### PR TITLE
chore(ci): separate web build into its own workflow

### DIFF
--- a/.github/workflows/build-web.yaml
+++ b/.github/workflows/build-web.yaml
@@ -1,0 +1,58 @@
+name: Build Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lib/**'
+      - 'pubspec.*'
+      - 'web/**'
+      - 'packages/soliplex_agent/**'
+      - 'packages/soliplex_client/**'
+      - 'packages/soliplex_client_native/**'
+      - 'packages/soliplex_logging/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Dart environment
+        uses: ./.github/actions/setup-dart-env
+
+      - name: Build web
+        run: flutter build web --release
+
+      - name: Upload web artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-build
+          path: build/web/
+          retention-days: 7
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_NOTIFY_URL != ''
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ env.SLACK_NOTIFY_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "channel": "#soliplex",
+              "username": "flutter-ci",
+              "text": ${{ toJson(format(':x: Web build failed on {0}:\n{1}\n{2}/{3}/actions/runs/{4}', github.ref, github.event.head_commit.message, github.server_url, github.repository, github.run_id)) }},
+              "icon_emoji": ":flutter:"
+            }

--- a/.github/workflows/flutter.yaml
+++ b/.github/workflows/flutter.yaml
@@ -73,7 +73,6 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
-      app: ${{ steps.filter.outputs.app }}
     steps:
       - uses: actions/checkout@v6
 
@@ -217,40 +216,5 @@ jobs:
               "channel": "#soliplex",
               "username": "flutter-ci",
               "text": ${{ toJson(format(':x: Tests failed for {0} on {1}:\n{2}\n{3}/{4}/actions/runs/{5}', matrix.target.name, github.ref, github.event.head_commit.message, github.server_url, github.repository, github.run_id)) }},
-              "icon_emoji": ":flutter:"
-            }
-
-  build-web:
-    needs: [lint, changes]
-    if: needs.changes.outputs.app == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Dart environment
-        uses: ./.github/actions/setup-dart-env
-
-      - name: Build web
-        run: flutter build web --release
-
-      - name: Upload web artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: web-build
-          path: build/web/
-          retention-days: 7
-
-      - name: Notify Slack on failure
-        if: failure() && env.SLACK_NOTIFY_URL != ''
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          webhook: ${{ env.SLACK_NOTIFY_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "channel": "#soliplex",
-              "username": "flutter-ci",
-              "text": ${{ toJson(format(':x: Web build failed on {0}:\n{1}\n{2}/{3}/actions/runs/{4}', github.ref, github.event.head_commit.message, github.server_url, github.repository, github.run_id)) }},
               "icon_emoji": ":flutter:"
             }


### PR DESCRIPTION
## Summary
- Move `build-web` out of `flutter.yaml` into standalone `build-web.yaml`
- Flutter CI (lint + tests) can go fully green without waiting on a web build
- Web build only triggers on pushes to `main` (not PRs) with app-relevant path filters

## Changes
- **`flutter.yaml`**: removed `build-web` job and the unused `app` output from the `changes` job
- **`build-web.yaml`** (new): standalone workflow with path filters for `lib/`, `pubspec.*`, `web/`, and relevant packages

## Test plan
- [x] `flutter.yaml` no longer contains a `build-web` job
- [ ] PR CI shows only lint + test jobs (no web build)
- [ ] After merge, push to main with app changes triggers `Build Web` workflow separately