### PR TITLE
docs(team-readiness): audit packages, fix pre-commit, add READMEs and CONTRIBUTING

### DIFF
--- a/.dart_analyze_skip
+++ b/.dart_analyze_skip
@@ -1,7 +1,2 @@
 # Packages to skip during pre-commit dart analysis.
-# These have pre-existing issues tracked separately.
-soliplex_agent
-soliplex_cli
-soliplex_interpreter_monty
-soliplex_skills
-soliplex_tui
+# All packages currently pass analysis. Keep this file for future use.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,135 @@
+# Contributing to Soliplex Flutter
+
+## Branch Naming
+
+- `feat/<name>` -- New features
+- `fix/<issue>` -- Bug fixes
+- `refactor/<area>` -- Code restructuring
+- `docs/<topic>` -- Documentation changes
+
+## Commit Format
+
+```text
+<type>(<scope>): <description>
+
+<body — what changed and why>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+
+**Example:**
+
+```text
+feat(agent): add multi-server runtime support
+
+Add ServerConnection, ServerRegistry, and AgentRuntime.fromConnection
+to support concurrent connections to multiple Soliplex servers.
+```
+
+## Pull Request Process
+
+1. Create a branch off `main` using the naming convention above.
+2. Make your changes, ensuring all checks pass (see below).
+3. Push and open a PR against `main`.
+
+**PR title:** `<type>(<scope>): <title>` (matches commit format).
+
+**PR body:**
+
+```text
+## Summary
+- Bullet points
+
+## Changes
+- **Component**: Description
+
+## Test plan
+- [x] Manual steps
+- [x] Automated pass
+```
+
+## Pre-Commit Hooks
+
+This repo uses [pre-commit](https://pre-commit.com/) to enforce code quality.
+
+### Setup
+
+```bash
+# Install pre-commit (once)
+pip install pre-commit   # or: brew install pre-commit
+
+# Install hooks into this repo
+pre-commit install
+```
+
+### What Runs
+
+| Hook | What it does |
+|------|-------------|
+| `no-commit-to-branch` | Blocks direct commits to `main`/`master` |
+| `check-merge-conflict` | Catches unresolved merge markers |
+| `gitleaks` | Scans for leaked secrets |
+| `dart-format` | Enforces `dart format` on all `.dart` files |
+| `flutter-analyze` | Runs `dart analyze --fatal-infos` on app `lib/` and `test/` |
+| `dcm-analyze` | Runs DCM analysis on `lib/` (optional — skips if `dcm` is not installed) |
+| `dart-analyze-packages` | Runs `dart analyze --fatal-infos` on all 12 packages |
+| `pymarkdown` | Lints all Markdown files |
+
+### DCM (Optional but Recommended)
+
+[DCM](https://dcm.dev) (Dart Code Metrics) provides additional static analysis
+beyond what `dart analyze` covers. It is **optional** for local development —
+the pre-commit hook skips gracefully if `dcm` is not installed.
+
+CI enforces DCM, so install it locally to catch issues early:
+
+```bash
+# macOS
+brew install nicklockwood/formulae/dcm
+
+# Other platforms: see https://dcm.dev/docs/getting-started/
+```
+
+## Testing
+
+### Per-Package
+
+```bash
+cd packages/<package_name>
+
+# Pure Dart packages
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+
+# Flutter packages (soliplex_client_native, soliplex_monty)
+flutter pub get
+flutter test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+### App-Level
+
+```bash
+# From repo root
+flutter pub get
+flutter test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos lib/ test/
+```
+
+### Coverage Target
+
+Aim for 85%+ coverage on new and changed code.
+
+## Code Style
+
+- Linting: `very_good_analysis` (all packages)
+- Formatting: `dart format` (enforced by pre-commit)
+- No `// ignore:` directives — restructure code instead
+- Pure Dart packages must not import `package:flutter/*`
+- Platform-specific code goes in `soliplex_client_native`
+- See [docs/rules/flutter_rules.md](docs/rules/flutter_rules.md) for full
+  conventions

--- a/PLANS/0011-ci-pipeline-optimization/plan.md
+++ b/PLANS/0011-ci-pipeline-optimization/plan.md
@@ -7,7 +7,7 @@ and separate the web build from the test pipeline.
 
 ## Dependency Graph
 
-```
+```text
 soliplex_logging           (leaf)
 soliplex_schema            (leaf)
 soliplex_interpreter_monty (leaf)
@@ -67,11 +67,11 @@ Each filter includes the package itself plus all of its transitive dependencies:
 
 ### `setup-dart-env/action.yaml`
 
-6. **Use `dart-lang/setup-dart` for dart-only packages** instead of full Flutter SDK — faster install, smaller download
+1. **Use `dart-lang/setup-dart` for dart-only packages** instead of full Flutter SDK — faster install, smaller download
 
 ### Additional optimizations (from Gemini review)
 
-7. **Cache pip installs**: Use `actions/setup-python` with `cache: 'pip'` for `diff-cover`/`lcov_cobertura` and `pymarkdownlnt`
+1. **Cache pip installs**: Use `actions/setup-python` with `cache: 'pip'` for `diff-cover`/`lcov_cobertura` and `pymarkdownlnt`
 
 ### Files unchanged
 

--- a/docs/design/multi-server-review-gate.md
+++ b/docs/design/multi-server-review-gate.md
@@ -53,7 +53,8 @@ Copy it and run with `model="gemini-3.1-pro-preview"`.
 ## Output Location
 
 Review artifacts land in:
-```
+
+```text
 ~/dev/soliplex-plans/ci-review/multi-server-support/slice-reviews/
   m{N}-prompt.md   # Review prompt
   m{N}.diff         # Unified diff

--- a/docs/design/multi-server-test-plan.md
+++ b/docs/design/multi-server-test-plan.md
@@ -47,6 +47,7 @@ final ToolRegistryResolver stubResolver =
 | 5 | `toString contains serverId` | `conn.toString().contains(serverId)` | Debuggability |
 
 **Done when:**
+
 - 5/5 tests green
 - `dart analyze --fatal-infos` clean
 - Export visible from `import 'package:soliplex_agent/soliplex_agent.dart'`
@@ -69,6 +70,7 @@ final ToolRegistryResolver stubResolver =
 | 10 | `isEmpty and length` | Empty → `isEmpty == true, length == 0`; after add → `false, 1` | Boundary conditions |
 
 **Done when:**
+
 - 10/10 tests green
 - `dart analyze --fatal-infos` clean
 - Export visible from barrel
@@ -84,6 +86,7 @@ final ToolRegistryResolver stubResolver =
 | 3 | `existing tests still pass` | No regressions | Non-breaking change |
 
 **Done when:**
+
 - 2 new tests green + all existing `agent_runtime_test.dart` tests green
 - `dart analyze --fatal-infos` clean
 
@@ -166,6 +169,7 @@ test('Phase 1: registry → connection → runtime → session', () async {
 | 17 | `concurrent dispose is safe` | `Future.wait([msr.dispose(), msr.dispose()])` completes without error |
 
 **Done when:**
+
 - 17/17 tests green
 - `dart analyze --fatal-infos` clean
 - Export visible from barrel
@@ -231,6 +235,7 @@ test('Phase 2: multi-server spawn + waitAll', () async {
 | 8 | `serverIdFor unknown tool` | `serverIdFor('nope')` → `null` |
 
 **Done when:**
+
 - 8/8 tests green
 - `dart analyze --fatal-infos` clean
 - Both `ServerScopedToolRegistryResolver` and `FederatedToolRegistry` exported from barrel
@@ -259,6 +264,7 @@ test('Phase 2: multi-server spawn + waitAll', () async {
 | 9 | `federated tool execution routes correctly end-to-end` | Call `prod::weather` via session → dispatches to prod server's executor |
 
 **Done when:**
+
 - 9/9 tests green (6 resolver + 3 integration)
 - `dart analyze --fatal-infos` clean
 - All Phase 1 and Phase 2 tests still pass

--- a/docs/guides/developer-setup.md
+++ b/docs/guides/developer-setup.md
@@ -5,23 +5,72 @@ Flutter frontend.
 
 ## Prerequisites
 
-- Flutter SDK (stable channel)
+- Flutter SDK (stable channel, Dart >= 3.6.0)
 - Xcode (for iOS/macOS)
 - CocoaPods (`gem install cocoapods`)
+- [pre-commit](https://pre-commit.com/) (`pip install pre-commit` or
+  `brew install pre-commit`)
+- [DCM](https://dcm.dev) (optional but recommended — see
+  [CONTRIBUTING.md](../../CONTRIBUTING.md))
 
 ## Quick Start
 
 ```bash
-# Install dependencies
+# 1. Install pre-commit hooks
+pre-commit install
+
+# 2. Install app dependencies
 flutter pub get
 
-# Install iOS/macOS pods
+# 3. Install package dependencies (all 12 packages)
+for pkg in packages/*/; do
+  if [ -f "$pkg/pubspec.yaml" ]; then
+    (cd "$pkg" && dart pub get 2>/dev/null || flutter pub get)
+  fi
+done
+
+# 4. Install iOS/macOS pods
 cd ios && pod install && cd ..
 cd macos && pod install && cd ..
 
-# Run the app
-flutter run -d macos   # or: -d ios, -d chrome
+# 5. Run the app
+flutter run -d macos   # or: -d ios, -d chrome --web-port 59001
 ```
+
+## Package Development
+
+The repo contains 12 packages under `packages/`. See
+[packages/README.md](../../packages/README.md) for the full list and dependency
+graph.
+
+```bash
+# Work on a specific package
+cd packages/<package_name>
+dart pub get            # or: flutter pub get (for Flutter packages)
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+Flutter packages (require `flutter` commands):
+`soliplex_client_native`, `soliplex_monty`
+
+All other packages are pure Dart and use `dart` commands.
+
+## Backend Connection
+
+The app connects to a Soliplex backend server. For local development:
+
+```bash
+# Default: http://localhost:8080
+# Configure via the app's Settings screen or at login
+```
+
+Common backend setups:
+
+- **Local backend:** `http://localhost:8080` (see the backend repo for setup)
+- **No-auth mode:** Start the backend with `--no-auth-mode` to skip OIDC
+  during development
 
 ## Platform Setup
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,64 @@
+# Soliplex Packages
+
+This directory contains 12 self-contained packages that make up the Soliplex
+monorepo. Each package has its own `pubspec.yaml`, test suite, and README.
+
+## Dependency Graph
+
+```text
+soliplex_logging           (leaf — pure Dart)
+soliplex_schema            (leaf — pure Dart)
+soliplex_dataframe         (leaf — pure Dart)
+soliplex_skills            (leaf — pure Dart)
+soliplex_interpreter_monty (leaf — pure Dart)
+
+soliplex_client            → logging
+soliplex_client_native     → client                         (Flutter)
+soliplex_agent             → client, logging
+soliplex_scripting         → agent, client, dataframe, interpreter_monty
+soliplex_cli               → agent, client, logging
+soliplex_tui               → agent, logging
+soliplex_monty             → interpreter_monty (via dart_monty)  (Flutter)
+```
+
+## Package Overview
+
+| Package | Type | Description |
+|---------|------|-------------|
+| [soliplex_logging](soliplex_logging/) | Pure Dart | Centralized logging, DiskQueue, BackendLogSink |
+| [soliplex_schema](soliplex_schema/) | Pure Dart | Runtime JSON Schema parsing for AG-UI features |
+| [soliplex_dataframe](soliplex_dataframe/) | Pure Dart | Pandas-like DataFrame engine with handle-based registry |
+| [soliplex_skills](soliplex_skills/) | Pure Dart | Skill loading and execution (.md and .py files) |
+| [soliplex_interpreter_monty](soliplex_interpreter_monty/) | Pure Dart | Monty Python sandbox bridge |
+| [soliplex_client](soliplex_client/) | Pure Dart | REST API client, AG-UI protocol, domain models |
+| [soliplex_client_native](soliplex_client_native/) | Flutter | Native HTTP platform adapters (Cupertino) |
+| [soliplex_agent](soliplex_agent/) | Pure Dart | Agent orchestration (RunOrchestrator, AgentRuntime) |
+| [soliplex_scripting](soliplex_scripting/) | Pure Dart | Wires AG-UI events to the Monty interpreter bridge |
+| [soliplex_cli](soliplex_cli/) | Pure Dart | Interactive REPL for exercising soliplex_agent |
+| [soliplex_tui](soliplex_tui/) | Pure Dart | Rich terminal UI for the agent backend |
+| [soliplex_monty](soliplex_monty/) | Flutter | Monty Python bridge with Flutter widgets |
+
+## Working on a Package
+
+```bash
+cd packages/<package_name>
+
+# Pure Dart packages
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+
+# Flutter packages (soliplex_client_native, soliplex_monty)
+flutter pub get
+flutter test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Rules
+
+- Pure Dart packages must not import `package:flutter/*`.
+- Platform-specific code goes in `soliplex_client_native`.
+- All packages use `very_good_analysis` for linting.
+- Each package must pass `dart analyze --fatal-infos` with zero issues.

--- a/packages/soliplex_dataframe/README.md
+++ b/packages/soliplex_dataframe/README.md
@@ -1,0 +1,54 @@
+# soliplex_dataframe
+
+A pure Dart DataFrame engine providing a familiar, pandas-like API for in-memory data manipulation. It includes a handle-based registry for managing DataFrame instances, facilitating interoperability with external runtimes in Soliplex.
+
+## Quick Start
+
+```bash
+cd packages/soliplex_dataframe
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Architecture
+
+### Core
+
+- `DataFrame` -- An immutable, in-memory data table backed by a `List<Map<String, dynamic>>`. It provides a rich API for common data manipulation tasks like filtering, sorting, selecting, grouping, and aggregation.
+- `DfRegistry` -- A handle-based storage and management system for `DataFrame` instances. It allows DataFrames to be created, retrieved, and disposed of using integer handles, which is essential for communication with external language runtimes that cannot directly manage Dart objects.
+
+## Dependencies
+
+- `meta` -- Provides annotations like `@immutable` to improve code analysis and clarity.
+
+## Example
+
+```dart
+import 'package:soliplex_dataframe/soliplex_dataframe.dart';
+
+void main() {
+  // The registry manages DataFrames using integer handles.
+  final registry = DfRegistry();
+
+  // Create a DataFrame from a list of maps.
+  final data = [
+    {'city': 'New York', 'temperature': 15.2, 'humidity': 65},
+    {'city': 'London', 'temperature': 8.5, 'humidity': 81},
+    {'city': 'Tokyo', 'temperature': 18.3, 'humidity': 70},
+    {'city': 'Sydney', 'temperature': 22.1, 'humidity': 55},
+  ];
+
+  final dfHandle = registry.create(data);
+  final df = registry.get(dfHandle);
+
+  // Filter for cities with temperature above 15 degrees.
+  final warmCities = df.filter('temperature', '>', 15);
+
+  // Select specific columns and print the result as a CSV string.
+  final result = warmCities.select(['city', 'temperature']);
+
+  print(result.toCsv());
+}
+```

--- a/packages/soliplex_monty/README.md
+++ b/packages/soliplex_monty/README.md
@@ -1,0 +1,80 @@
+# soliplex_monty
+
+Flutter package bridging the Monty sandboxed Python interpreter into the Soliplex application. It enables execution of Python code -- including LLM-generated code that can call back to registered Dart host functions -- and provides Flutter widgets for interactive Python consoles.
+
+## Quick Start
+
+```bash
+cd packages/soliplex_monty
+flutter pub get
+flutter test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Architecture
+
+### Bridge
+
+- `MontyBridge` -- Abstract interface for executing Python code that can call registered Dart host functions, emitting a stream of AG-UI `BaseEvent`s.
+- `DefaultMontyBridge` -- The default `MontyBridge` implementation that orchestrates the Monty start/resume loop and dispatches calls to host functions.
+- `HostFunctionRegistry` -- Groups `HostFunction`s by category and registers them (plus introspection built-ins) onto a `MontyBridge`.
+- `HostFunction` -- A Dart function callable from Python, composed of a `HostFunctionSchema` and a `HostFunctionHandler`.
+- `HostFunctionSchema` -- Defines the name, description, and parameters for a `HostFunction`.
+- `HostParam` -- Defines a single parameter for a `HostFunctionSchema`.
+- `HostParamType` -- Enum of supported data types for a `HostParam` (`string`, `int`, `float`, `bool`, `list`, `map`).
+- `ToolDefinitionConverter` -- Converts `HostFunctionSchema`s into AG-UI `Tool` definitions for an LLM.
+
+### Execution
+
+- `MontyExecutionService` -- A simplified service to execute Python code and stream console output, without host function support.
+- `ExecutionResult` -- Contains the return value, resource usage, and console output of a successful execution.
+- `ConsoleEvent` -- A sealed class for events from `MontyExecutionService`: `ConsoleOutput`, `ConsoleComplete`, `ConsoleError`.
+
+### Widgets
+
+- `PythonRunButton` -- An `IconButton` that executes Python code via `MontyExecutionService`, optionally collecting user input via a form dialog.
+- `ConsoleOutputView` -- A widget that renders a stream of `ConsoleEvent`s as a formatted, auto-scrolling console.
+
+### Data and Tools
+
+- `DataFrame` -- Represents tabular data that can be manipulated by Python code.
+- `DfRegistry` -- Manages `DataFrame` instances by name, making them accessible to Python.
+- `buildDfFunctions()` -- Provides a set of built-in `HostFunction`s for creating and manipulating `DataFrame`s from Python.
+- `SchemaExecutor` -- Executes Python-based schema validators against JSON data at runtime.
+- `PythonExecutorTool` -- Defines the `execute_python` tool schema for use with an agent framework.
+- `InputVariable` -- Describes a variable to be collected from the user before executing code with `PythonRunButton`.
+- `InputVariableType` -- Enum of supported types for an `InputVariable` (`string`, `int`, `float`, `bool`).
+- `MontyLimitsDefaults` -- Provides default `MontyLimits` constants for different execution contexts (e.g., `tool`, `playButton`).
+
+## Dependencies
+
+- `ag_ui` -- Provides the `Tool` and `BaseEvent` models for integration with the agent framework.
+- `dart_monty_platform_interface` -- Core platform interface for interacting with the sandboxed Monty Python interpreter.
+- `flutter` -- Flutter framework for widgets.
+- `meta` -- Annotations like `@immutable`.
+
+## Example
+
+```dart
+import 'package:soliplex_monty/soliplex_monty.dart';
+
+void main() async {
+  // 1. Create a simple execution service (no host functions).
+  final service = MontyExecutionService();
+
+  // 2. Execute Python code and listen for console events.
+  await for (final event in service.execute('print("Hello from Python!")')) {
+    switch (event) {
+      case ConsoleOutput(:final text):
+        print('OUTPUT: $text');
+      case ConsoleComplete(:final result):
+        print('Done. Return value: ${result.value}');
+      case ConsoleError(:final error):
+        print('Error: ${error.message}');
+    }
+  }
+
+  service.dispose();
+}
+```

--- a/packages/soliplex_schema/README.md
+++ b/packages/soliplex_schema/README.md
@@ -1,0 +1,83 @@
+# soliplex_schema
+
+Runtime parsing of JSON Schemas for AG-UI features with typed, safe views for accessing feature state. This is the client-side contract and access layer for dynamic feature data sent from the server.
+
+## Quick Start
+
+```bash
+cd packages/soliplex_schema
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Architecture
+
+### Schema Parsing and Registration
+
+- `SchemaParser` -- Parses a raw JSON Schema map into a structured `ObjectSchema`, resolving `$ref`s and other keywords.
+- `FeatureSchemaRegistry` -- A global cache for parsed schemas, organized by room ID and feature name.
+
+### Schema Models
+
+- `FeatureSchema` -- Represents the complete schema for a single AG-UI feature, including metadata and the root `ObjectSchema`.
+- `ObjectSchema` -- Represents a parsed JSON schema `object` type, containing a map of its `FieldSchema` properties.
+- `FieldSchema` -- Represents a single property within an `ObjectSchema`, detailing its type, constraints, and nested schemas.
+- `FeatureSource` -- An enum (`CLIENT`, `SERVER`, `EITHER`) that specifies which system has write-ownership of a feature's state.
+- `FieldType` -- An enum representing the fundamental JSON Schema data types (`string`, `object`, `array`, etc.).
+
+### State Access
+
+- `SchemaStateView` -- A zero-copy, typed wrapper over a `Map<String, dynamic>` that provides safe, lenient access to feature state according to its `ObjectSchema`.
+
+## Dependencies
+
+- `meta` -- For annotations like `@immutable` to enforce class contracts.
+
+## Example
+
+```dart
+import 'package:soliplex_schema/soliplex_schema.dart';
+
+void main() {
+  // 1. Initialize the registry.
+  final registry = FeatureSchemaRegistry();
+
+  // 2. Register schemas for a room (e.g., from an API call).
+  final roomId = 'room123';
+  final rawFeatureSchemas = {
+    'my_feature': {
+      'name': 'my_feature',
+      'description': 'A sample feature.',
+      'source': 'SERVER',
+      'json_schema': {
+        'type': 'object',
+        'properties': {
+          'title': {'type': 'string', 'default': 'Untitled'},
+          'is_enabled': {'type': 'boolean'},
+        },
+        'required': ['is_enabled'],
+      },
+    },
+  };
+  registry.register(roomId, rawFeatureSchemas);
+
+  // 3. Get a typed view for the current feature state.
+  final aguiState = {
+    'my_feature': {
+      'title': 'My Awesome Feature',
+      'is_enabled': true,
+    },
+  };
+
+  final featureView = registry.viewFor(roomId, 'my_feature', aguiState);
+
+  if (featureView != null) {
+    // 4. Safely access data.
+    final title = featureView.getScalar<String>('title');
+    final isEnabled = featureView.getScalar<bool>('is_enabled');
+    print('Title: $title, Enabled: $isEnabled');
+  }
+}
+```

--- a/packages/soliplex_skills/README.md
+++ b/packages/soliplex_skills/README.md
@@ -1,0 +1,71 @@
+# soliplex_skills
+
+Shared skill loading and execution for Soliplex. Skills are composable behaviors defined as `.md` (message injection) or `.py` (Python sandbox) files.
+
+## Quick Start
+
+```bash
+cd packages/soliplex_skills
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Architecture
+
+### Model
+
+- `Skill` -- Sealed base class for a loadable skill.
+- `MarkdownSkill` -- A skill whose body is a Markdown prompt injected as a chat message.
+- `PythonSkill` -- A skill whose body is Python code executed in a sandbox.
+- `SkillMetadata` -- Metadata for a skill, parsed from its YAML frontmatter.
+
+### Loading
+
+- `SkillSource` -- Interface for a source of skills (e.g., filesystem, server).
+- `FilesystemSkillSource` -- Loads skills from a local directory.
+- `ServerSkillSource` -- Loads skills from a remote server API.
+- `SkillParser` -- Static utility class to parse `.md` and `.py` files into `Skill` objects.
+- `SkillLoadException` -- An exception thrown when a skill fails to load.
+
+### Execution
+
+- `SkillResult` -- Sealed base class for the result of executing a skill.
+- `MessageInjection` -- Result of a `MarkdownSkill`, representing a chat message to be injected.
+- `ExecutionOutput` -- Result of a `PythonSkill`, containing stdout and an optional error.
+- `MessageRole` -- An enum (`system`, `user`) for the role of an injected message.
+- `PythonRunner` -- A `typedef` for a function that can execute Python code, injected by the host.
+
+### Registry
+
+- `SkillRegistry` -- An immutable collection of loaded skills, searchable by name and category.
+
+## Dependencies
+
+- `meta` -- For annotations like `@immutable` to enforce class contracts.
+- `path` -- For cross-platform file path manipulation in `FilesystemSkillSource`.
+- `yaml` -- For parsing YAML frontmatter from skill files.
+
+## Example
+
+```dart
+import 'dart:io';
+import 'package:soliplex_skills/soliplex_skills.dart';
+
+Future<void> main() async {
+  // 1. Load skills from a directory.
+  final source = FilesystemSkillSource(Directory('path/to/skills'));
+  final skills = await source.load();
+
+  // 2. Build a registry.
+  final registry = SkillRegistry(skills);
+
+  // 3. Look up a skill by name.
+  final skill = registry.lookup('hello-world');
+  if (skill is PythonSkill) {
+    print('Found Python skill: ${skill.metadata.name}');
+    print('Code: ${skill.body}');
+  }
+}
+```

--- a/packages/soliplex_tui/README.md
+++ b/packages/soliplex_tui/README.md
@@ -1,0 +1,67 @@
+# soliplex_tui
+
+Rich terminal user interface for interacting with the Soliplex agent backend. It serves as the primary pure-Dart client for developers and headless environments.
+
+## Quick Start
+
+```bash
+cd packages/soliplex_tui
+dart pub get
+dart test
+dart format . --set-exit-if-changed
+dart analyze --fatal-infos
+```
+
+## Architecture
+
+### Entry Points
+
+- `launchTui()` -- Start the interactive TUI application.
+- `runHeadless()` -- Send a single message, print the final response, and exit.
+- `listRooms()` -- List available rooms on the server.
+
+### State Management
+
+- `TuiChatCubit` -- Manages the chat state by listening to the `RunOrchestrator` and handling user input.
+- `TuiChatState` -- Abstract base class for all chat UI states.
+- `TuiIdleState` -- The application is awaiting user input.
+- `TuiStreamingState` -- An AG-UI response is actively being streamed.
+- `TuiExecutingToolsState` -- The client is executing tool calls yielded by the agent.
+- `TuiErrorState` -- Displays a fatal error.
+
+### UI Components
+
+- `SoliplexTuiApp` -- The root `nocterm` component that sets up the theme and initial page.
+- `ChatPage` -- The main screen component, containing the header, chat body, input row, and footer.
+- `ChatBody` -- A scrollable component that displays the list of chat messages.
+- `InputRow` -- The text input field with a prompt for the user to type messages.
+- `MessageItem` -- Renders a single, finalized `ChatMessage`.
+- `StreamingMessageItem` -- Renders the in-progress assistant message as it streams.
+
+### Utilities
+
+- `Loggers` -- A namespace providing static access to pre-configured loggers for different subsystems.
+- `FileSink` -- A `LogSink` implementation that writes log records to a specified file.
+
+## Dependencies
+
+- `nocterm` -- The core terminal UI framework used to build the entire interface.
+- `nocterm_bloc` -- `BlocProvider` and `BlocBuilder` components for integrating state management with the UI.
+- `soliplex_agent` -- Core agent interaction logic, including `RunOrchestrator` and data models.
+- `soliplex_logging` -- Shared logging framework.
+- `bloc` -- State management library used by `TuiChatCubit`.
+- `args` -- Command-line argument parsing.
+
+## Example
+
+```dart
+import 'package:soliplex_tui/soliplex_tui.dart';
+
+Future<void> main() async {
+  // Launch the interactive terminal UI.
+  await launchTui(
+    serverUrl: 'http://localhost:8080',
+    logFile: 'soliplex_tui.log',
+  );
+}
+```

--- a/tool/HOWTO.md
+++ b/tool/HOWTO.md
@@ -6,7 +6,7 @@ full validation.
 
 ## Overview
 
-```
+```text
 feature branch (messy commits)
         │
         ▼
@@ -172,7 +172,7 @@ After validation, the script produces a review package in `.validation/`:
 
 To run the review with Gemini MCP:
 
-```
+```text
 mcp__gemini__read_files(
   file_paths: <contents of gemini_review_files.txt>,
   prompt: <contents of gemini_review_prompt.txt>

--- a/tool/validate_pr.sh
+++ b/tool/validate_pr.sh
@@ -170,35 +170,40 @@ log_step "DCM ANALYSIS"
 
 dcm_failed=false
 
-# Extract changed .dart lib files from diff (not test files)
-CHANGED_DART_FILES=()
-while IFS= read -r f; do
-  if [[ "$f" == *.dart && "$f" == lib/* ]] || [[ "$f" == *.dart && "$f" == packages/*/lib/* ]]; then
-    if [[ -f "$f" ]]; then
-      CHANGED_DART_FILES+=("$f")
-    fi
-  fi
-done < <(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git diff --name-only "$BASE_BRANCH"..HEAD)
-
-if [[ ${#CHANGED_DART_FILES[@]} -eq 0 ]]; then
-  echo "No changed .dart lib files — skipping DCM"
-  log_pass "dcm analyze: skipped (no changed dart files)"
+if ! command -v dcm &>/dev/null; then
+  echo "dcm not installed — skipping (install from https://dcm.dev)"
+  log_pass "dcm analyze: skipped (dcm not installed)"
 else
-  echo "DCM analyzing ${#CHANGED_DART_FILES[@]} changed file(s)..."
-  # Run DCM on each changed file individually to avoid scope bleed
-  dcm_issues=0
-  for dart_file in "${CHANGED_DART_FILES[@]}"; do
-    dcm_out=$(env -u GIT_DIR -u GIT_WORK_TREE dcm analyze "$dart_file" --fatal-warnings 2>&1) || {
-      echo "$dcm_out"
-      dcm_issues=$((dcm_issues + 1))
-    }
-  done
+  # Extract changed .dart lib files from diff (not test files)
+  CHANGED_DART_FILES=()
+  while IFS= read -r f; do
+    if [[ "$f" == *.dart && "$f" == lib/* ]] || [[ "$f" == *.dart && "$f" == packages/*/lib/* ]]; then
+      if [[ -f "$f" ]]; then
+        CHANGED_DART_FILES+=("$f")
+      fi
+    fi
+  done < <(git diff --name-only "$BASE_BRANCH"...HEAD 2>/dev/null || git diff --name-only "$BASE_BRANCH"..HEAD)
 
-  if [[ $dcm_issues -eq 0 ]]; then
-    log_pass "dcm analyze: ${#CHANGED_DART_FILES[@]} file(s) clean"
+  if [[ ${#CHANGED_DART_FILES[@]} -eq 0 ]]; then
+    echo "No changed .dart lib files — skipping DCM"
+    log_pass "dcm analyze: skipped (no changed dart files)"
   else
-    log_fail "dcm analyze: $dcm_issues file(s) with issues"
-    dcm_failed=true
+    echo "DCM analyzing ${#CHANGED_DART_FILES[@]} changed file(s)..."
+    # Run DCM on each changed file individually to avoid scope bleed
+    dcm_issues=0
+    for dart_file in "${CHANGED_DART_FILES[@]}"; do
+      dcm_out=$(env -u GIT_DIR -u GIT_WORK_TREE dcm analyze "$dart_file" --fatal-warnings 2>&1) || {
+        echo "$dcm_out"
+        dcm_issues=$((dcm_issues + 1))
+      }
+    done
+
+    if [[ $dcm_issues -eq 0 ]]; then
+      log_pass "dcm analyze: ${#CHANGED_DART_FILES[@]} file(s) clean"
+    else
+      log_fail "dcm analyze: $dcm_issues file(s) with issues"
+      dcm_failed=true
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary

- Audit all 12 packages: every package passes `dart analyze --fatal-infos`
- Clear `.dart_analyze_skip` from 5 entries to 0
- Make DCM opt-in in pre-commit and `validate_pr.sh` (`command -v` guard)
- Fix 53 `require_trailing_commas` lint issues across app `lib/` and `test/`
- Fix 8 pymarkdown violations in `tool/HOWTO.md`, `PLANS/`, `docs/design/`
- Add READMEs for `soliplex_dataframe`, `soliplex_monty`, `soliplex_schema`, `soliplex_skills`, `soliplex_tui`
- Add `packages/README.md` with dependency graph and package overview table
- Add `CONTRIBUTING.md` with branch naming, commit format, PR process, pre-commit setup, testing expectations, and code style
- Update `docs/guides/developer-setup.md` with monorepo workflow, package development commands, and backend connection info

## Changes

- **`.dart_analyze_skip`**: Cleared — all packages now analyzed in pre-commit
- **`.pre-commit-config.yaml`**: DCM hook skips gracefully if `dcm` not installed
- **`tool/validate_pr.sh`**: Same DCM opt-in guard
- **`packages/soliplex_interpreter_monty/example/example.dart`**: Fix unused import + ignore directives
- **`lib/`, `test/`**: Auto-fix `require_trailing_commas` + `dart format`
- **`tool/HOWTO.md`, `PLANS/`, `docs/design/`**: Fix fenced code block languages, list spacing
- **`docs/guides/developer-setup.md`**: Add pre-commit, package dev workflow, backend connection
- **New files**: 5 package READMEs, `packages/README.md`, `CONTRIBUTING.md`

## Test plan

- [x] `pre-commit run --all-files` passes all 10 hooks
- [x] `python3 tool/analyze_packages.py` passes all 12 packages
- [x] All new markdown files pass `pymarkdown` lint
- [x] `dart analyze --fatal-infos lib/ test/` clean (app level)

## Related

- #46 — follow-up to rename `soliplex_monty` package