### PR TITLE
feat(showcase): 12-demo Monty showcase with streaming, LLM, and interactive widgets

### DIFF
--- a/lib/core/providers/flutter_host_api.dart
+++ b/lib/core/providers/flutter_host_api.dart
@@ -9,14 +9,18 @@ import 'package:soliplex_frontend/features/debug/debug_chart_config.dart';
 /// so that df_* host functions and [HostApi] methods operate on the same store.
 ///
 /// [onChartCreated] is called when Python code calls `chart_create(config)`.
+/// [onChartUpdated] is called when Python code calls
+/// `chart_update(id, config)`.
 /// Each call returns a NEW pair — never cached.
 ({HostApi hostApi, DfRegistry dfRegistry}) createFlutterHostBundle({
   required void Function(int id, DebugChartConfig config) onChartCreated,
+  void Function(int id, DebugChartConfig config)? onChartUpdated,
 }) {
   final registry = DfRegistry();
   final api = _FlutterHostApi(
     dfRegistry: registry,
     onChartCreated: onChartCreated,
+    onChartUpdated: onChartUpdated,
   );
   return (hostApi: api, dfRegistry: registry);
 }
@@ -30,6 +34,7 @@ class _FlutterHostApi implements HostApi {
   _FlutterHostApi({
     required DfRegistry dfRegistry,
     required this.onChartCreated,
+    this.onChartUpdated,
   }) : _dfRegistry = dfRegistry;
 
   final DfRegistry _dfRegistry;
@@ -37,6 +42,7 @@ class _FlutterHostApi implements HostApi {
   int _nextChartId = 1;
 
   final void Function(int id, DebugChartConfig config) onChartCreated;
+  final void Function(int id, DebugChartConfig config)? onChartUpdated;
 
   @override
   int registerDataFrame(Map<String, List<Object?>> columns) {
@@ -60,9 +66,7 @@ class _FlutterHostApi implements HostApi {
     final df = _dfRegistry.get(handle);
     if (df.rows.isEmpty) return {};
     final cols = df.columns;
-    return {
-      for (final col in cols) col: df.columnValues(col),
-    };
+    return {for (final col in cols) col: df.columnValues(col)};
   }
 
   @override
@@ -72,6 +76,15 @@ class _FlutterHostApi implements HostApi {
     final config = DebugChartConfig.fromMap(chartConfig);
     onChartCreated(id, config);
     return id;
+  }
+
+  @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) {
+    if (!_charts.containsKey(chartId)) return false;
+    _charts[chartId] = chartConfig;
+    final config = DebugChartConfig.fromMap(chartConfig);
+    onChartUpdated?.call(chartId, config);
+    return true;
   }
 
   @override

--- a/lib/features/debug/debug_chart_config.dart
+++ b/lib/features/debug/debug_chart_config.dart
@@ -41,6 +41,47 @@ sealed class DebugChartConfig {
           yLabel: map['y_label'] as String? ?? 'Y',
           points: _parsePoints(map['points']),
         ),
+      'pie' => PieChartConfig(
+          title: map['title'] as String? ?? '',
+          xLabel: map['x_label'] as String? ?? '',
+          yLabel: map['y_label'] as String? ?? '',
+          labels: (map['labels'] as List?)?.cast<String>() ?? [],
+          values: _parseDoubles(map['values']),
+          centerRadius: (map['center_radius'] as num?)?.toDouble() ?? 40,
+        ),
+      'radar' => RadarChartConfig(
+          title: map['title'] as String? ?? '',
+          xLabel: map['x_label'] as String? ?? '',
+          yLabel: map['y_label'] as String? ?? '',
+          axes: (map['axes'] as List?)?.cast<String>() ?? [],
+          values: _parseDoubles(map['values']),
+        ),
+      'image' => ImageConfig(
+          title: map['title'] as String? ?? '',
+          xLabel: map['x_label'] as String? ?? '',
+          yLabel: map['y_label'] as String? ?? '',
+          width: (map['width'] as num?)?.toInt() ?? 0,
+          height: (map['height'] as num?)?.toInt() ?? 0,
+          pixels: _parseInts(map['pixels']),
+        ),
+      'graph' => GraphConfig(
+          title: map['title'] as String? ?? '',
+          xLabel: map['x_label'] as String? ?? '',
+          yLabel: map['y_label'] as String? ?? '',
+          nodes: (map['nodes'] as List?)?.cast<String>() ?? [],
+          edges: _parseEdges(map['edges']),
+          positions: _parsePoints(map['positions']),
+        ),
+      'heatmap' => HeatmapConfig(
+          title: map['title'] as String? ?? '',
+          xLabel: map['x_label'] as String? ?? '',
+          yLabel: map['y_label'] as String? ?? '',
+          rows: (map['rows'] as num?)?.toInt() ?? 0,
+          cols: (map['cols'] as num?)?.toInt() ?? 0,
+          values: _parseDoubles(map['values']),
+          rowLabels: (map['row_labels'] as List?)?.cast<String>() ?? [],
+          colLabels: (map['col_labels'] as List?)?.cast<String>() ?? [],
+        ),
       _ => throw FormatException('Unknown chart type: $type', map),
     };
   }
@@ -66,6 +107,21 @@ List<math.Point<double>> _parsePoints(Object? raw) {
 List<double> _parseDoubles(Object? raw) {
   if (raw is! List) return [];
   return raw.map((v) => (v as num).toDouble()).toList();
+}
+
+List<int> _parseInts(Object? raw) {
+  if (raw is! List) return [];
+  return raw.map((v) => (v as num).toInt()).toList();
+}
+
+List<(int, int)> _parseEdges(Object? raw) {
+  if (raw is! List) return [];
+  return raw.map<(int, int)>((item) {
+    if (item is List && item.length >= 2) {
+      return ((item[0] as num).toInt(), (item[1] as num).toInt());
+    }
+    return (0, 0);
+  }).toList();
 }
 
 /// Line chart: series of (x, y) points connected by lines.
@@ -104,4 +160,90 @@ class ScatterChartConfig extends DebugChartConfig {
   });
 
   final List<math.Point<double>> points;
+}
+
+/// Pie chart: labelled slices with proportional values.
+class PieChartConfig extends DebugChartConfig {
+  const PieChartConfig({
+    required super.title,
+    required super.xLabel,
+    required super.yLabel,
+    required this.labels,
+    required this.values,
+    this.centerRadius = 40,
+  });
+
+  final List<String> labels;
+  final List<double> values;
+  final double centerRadius;
+}
+
+/// Radar chart: multi-axis polygon plot.
+class RadarChartConfig extends DebugChartConfig {
+  const RadarChartConfig({
+    required super.title,
+    required super.xLabel,
+    required super.yLabel,
+    required this.axes,
+    required this.values,
+  });
+
+  final List<String> axes;
+  final List<double> values;
+}
+
+/// Raw pixel image: flat RGBA byte array rendered as a bitmap.
+class ImageConfig extends DebugChartConfig {
+  const ImageConfig({
+    required super.title,
+    required super.xLabel,
+    required super.yLabel,
+    required this.width,
+    required this.height,
+    required this.pixels,
+  });
+
+  final int width;
+  final int height;
+
+  /// Flat RGBA byte array (length = width * height * 4).
+  final List<int> pixels;
+}
+
+/// Node-and-edge graph with positioned nodes.
+class GraphConfig extends DebugChartConfig {
+  const GraphConfig({
+    required super.title,
+    required super.xLabel,
+    required super.yLabel,
+    required this.nodes,
+    required this.edges,
+    required this.positions,
+  });
+
+  final List<String> nodes;
+  final List<(int, int)> edges;
+  final List<math.Point<double>> positions;
+}
+
+/// Grid-based heatmap with labeled rows and columns.
+class HeatmapConfig extends DebugChartConfig {
+  const HeatmapConfig({
+    required super.title,
+    required super.xLabel,
+    required super.yLabel,
+    required this.rows,
+    required this.cols,
+    required this.values,
+    required this.rowLabels,
+    required this.colLabels,
+  });
+
+  final int rows;
+  final int cols;
+
+  /// Flat values array (length = rows * cols), row-major order.
+  final List<double> values;
+  final List<String> rowLabels;
+  final List<String> colLabels;
 }

--- a/lib/features/debug/debug_chart_renderer.dart
+++ b/lib/features/debug/debug_chart_renderer.dart
@@ -1,6 +1,9 @@
 // TEMPORARY: Chart renderer for debug REPL —
 // remove after validation.
 
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:soliplex_frontend/features/debug/debug_chart_config.dart';
@@ -16,6 +19,11 @@ class DebugChartRenderer extends StatelessWidget {
         final LineChartConfig c => _LineChartView(config: c),
         final BarChartConfig c => _BarChartView(config: c),
         final ScatterChartConfig c => _ScatterChartView(config: c),
+        final PieChartConfig c => _PieChartView(config: c),
+        final RadarChartConfig c => _RadarChartView(config: c),
+        final ImageConfig c => _ImageView(config: c),
+        final GraphConfig c => _GraphView(config: c),
+        final HeatmapConfig c => _HeatmapView(config: c),
       };
 }
 
@@ -143,6 +151,333 @@ class _ScatterChartView extends StatelessWidget {
       ),
     );
   }
+}
+
+const _sliceColors = [
+  Colors.blue,
+  Colors.red,
+  Colors.green,
+  Colors.orange,
+  Colors.purple,
+  Colors.teal,
+  Colors.pink,
+  Colors.amber,
+];
+
+class _PieChartView extends StatelessWidget {
+  const _PieChartView({required this.config});
+  final PieChartConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    return PieChart(
+      PieChartData(
+        centerSpaceRadius: config.centerRadius,
+        sections: [
+          for (var i = 0; i < config.values.length; i++)
+            PieChartSectionData(
+              value: config.values[i],
+              title: i < config.labels.length
+                  ? config.labels[i]
+                  : '${config.values[i]}',
+              color: _sliceColors[i % _sliceColors.length],
+              radius: 60,
+              titleStyle: const TextStyle(
+                fontSize: 10,
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RadarChartView extends StatelessWidget {
+  const _RadarChartView({required this.config});
+  final RadarChartConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return RadarChart(
+      RadarChartData(
+        radarShape: RadarShape.polygon,
+        dataSets: [
+          RadarDataSet(
+            dataEntries: [
+              for (final v in config.values) RadarEntry(value: v),
+            ],
+            fillColor: color.withValues(alpha: 0.2),
+            borderColor: color,
+            borderWidth: 2,
+          ),
+        ],
+        getTitle: (index, _) {
+          if (index < config.axes.length) {
+            return RadarChartTitle(text: config.axes[index]);
+          }
+          return const RadarChartTitle(text: '');
+        },
+        tickCount: 4,
+        tickBorderData: BorderSide(
+          color: Theme.of(context).colorScheme.outline.withValues(
+                alpha: 0.3,
+              ),
+        ),
+        gridBorderData: BorderSide(
+          color: Theme.of(context).colorScheme.outline.withValues(
+                alpha: 0.3,
+              ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ImageView extends StatefulWidget {
+  const _ImageView({required this.config});
+  final ImageConfig config;
+
+  @override
+  State<_ImageView> createState() => _ImageViewState();
+}
+
+class _ImageViewState extends State<_ImageView> {
+  ui.Image? _image;
+
+  @override
+  void initState() {
+    super.initState();
+    _decodeImage();
+  }
+
+  @override
+  void didUpdateWidget(_ImageView old) {
+    super.didUpdateWidget(old);
+    if (old.config != widget.config) _decodeImage();
+  }
+
+  void _decodeImage() {
+    final c = widget.config;
+    if (c.width <= 0 || c.height <= 0 || c.pixels.isEmpty) return;
+    final bytes = Uint8List.fromList(c.pixels);
+    ui.decodeImageFromPixels(
+      bytes,
+      c.width,
+      c.height,
+      ui.PixelFormat.rgba8888,
+      (img) {
+        if (mounted) setState(() => _image = img);
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final img = _image;
+    if (img == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return Center(child: RawImage(image: img));
+  }
+}
+
+class _GraphView extends StatelessWidget {
+  const _GraphView({required this.config});
+  final GraphConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return CustomPaint(
+      painter: _GraphPainter(
+        config: config,
+        nodeColor: color,
+        edgeColor: Theme.of(context).colorScheme.outline,
+        labelColor: Theme.of(context).colorScheme.onSurface,
+      ),
+      size: Size.infinite,
+    );
+  }
+}
+
+class _GraphPainter extends CustomPainter {
+  _GraphPainter({
+    required this.config,
+    required this.nodeColor,
+    required this.edgeColor,
+    required this.labelColor,
+  });
+
+  final GraphConfig config;
+  final Color nodeColor;
+  final Color edgeColor;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (config.positions.isEmpty) return;
+
+    final edgePaint = Paint()
+      ..color = edgeColor
+      ..strokeWidth = 1.5
+      ..style = PaintingStyle.stroke;
+
+    final nodePaint = Paint()
+      ..color = nodeColor
+      ..style = PaintingStyle.fill;
+
+    // Scale positions to canvas.
+    final xs = config.positions.map((p) => p.x);
+    final ys = config.positions.map((p) => p.y);
+    final minX = xs.reduce((a, b) => a < b ? a : b);
+    final maxX = xs.reduce((a, b) => a > b ? a : b);
+    final minY = ys.reduce((a, b) => a < b ? a : b);
+    final maxY = ys.reduce((a, b) => a > b ? a : b);
+    final rangeX = maxX - minX;
+    final rangeY = maxY - minY;
+    const pad = 30.0;
+    final w = size.width - pad * 2;
+    final h = size.height - pad * 2;
+
+    Offset toCanvas(int i) {
+      final p = config.positions[i];
+      final dx = rangeX == 0 ? w / 2 : (p.x - minX) / rangeX * w;
+      final dy = rangeY == 0 ? h / 2 : (p.y - minY) / rangeY * h;
+      return Offset(pad + dx, pad + dy);
+    }
+
+    // Draw edges.
+    for (final (from, to) in config.edges) {
+      if (from < config.positions.length && to < config.positions.length) {
+        canvas.drawLine(toCanvas(from), toCanvas(to), edgePaint);
+      }
+    }
+
+    // Draw nodes.
+    for (var i = 0; i < config.positions.length; i++) {
+      final c = toCanvas(i);
+      canvas.drawCircle(c, 12, nodePaint);
+      if (i < config.nodes.length) {
+        final tp = TextPainter(
+          text: TextSpan(
+            text: config.nodes[i],
+            style: TextStyle(color: labelColor, fontSize: 10),
+          ),
+          textDirection: TextDirection.ltr,
+        )..layout();
+        tp.paint(canvas, c - Offset(tp.width / 2, tp.height + 14));
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_GraphPainter old) => old.config != config;
+}
+
+class _HeatmapView extends StatelessWidget {
+  const _HeatmapView({required this.config});
+  final HeatmapConfig config;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _HeatmapPainter(
+        config: config,
+        labelColor: Theme.of(context).colorScheme.onSurface,
+      ),
+      size: Size.infinite,
+    );
+  }
+}
+
+class _HeatmapPainter extends CustomPainter {
+  _HeatmapPainter({
+    required this.config,
+    required this.labelColor,
+  });
+
+  final HeatmapConfig config;
+  final Color labelColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (config.rows <= 0 || config.cols <= 0) return;
+    if (config.values.isEmpty) return;
+
+    const labelPad = 40.0;
+    final cellW = (size.width - labelPad) / config.cols;
+    final cellH = (size.height - labelPad) / config.rows;
+
+    // Find value range for color interpolation.
+    final minV = config.values.reduce(
+      (a, b) => a < b ? a : b,
+    );
+    final maxV = config.values.reduce(
+      (a, b) => a > b ? a : b,
+    );
+    final range = maxV - minV;
+
+    for (var r = 0; r < config.rows; r++) {
+      for (var c = 0; c < config.cols; c++) {
+        final idx = r * config.cols + c;
+        if (idx >= config.values.length) continue;
+        final t = range == 0 ? 0.5 : (config.values[idx] - minV) / range;
+        final color = Color.lerp(
+          Colors.blue.shade100,
+          Colors.red.shade700,
+          t,
+        )!;
+        canvas.drawRect(
+          Rect.fromLTWH(
+            labelPad + c * cellW,
+            r * cellH,
+            cellW,
+            cellH,
+          ),
+          Paint()..color = color,
+        );
+      }
+    }
+
+    // Row labels.
+    for (var r = 0; r < config.rowLabels.length; r++) {
+      final tp = TextPainter(
+        text: TextSpan(
+          text: config.rowLabels[r],
+          style: TextStyle(color: labelColor, fontSize: 9),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(
+        canvas,
+        Offset(2, r * cellH + (cellH - tp.height) / 2),
+      );
+    }
+
+    // Column labels.
+    for (var c = 0; c < config.colLabels.length; c++) {
+      final tp = TextPainter(
+        text: TextSpan(
+          text: config.colLabels[c],
+          style: TextStyle(color: labelColor, fontSize: 9),
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      tp.paint(
+        canvas,
+        Offset(
+          labelPad + c * cellW + (cellW - tp.width) / 2,
+          config.rows * cellH + 4,
+        ),
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_HeatmapPainter old) => old.config != config;
 }
 
 FlTitlesData _titlesData(String xLabel, String yLabel) => FlTitlesData(

--- a/lib/features/demos/monty_showcase/monty_showcase_screen.dart
+++ b/lib/features/demos/monty_showcase/monty_showcase_screen.dart
@@ -1,191 +1,19 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:soliplex_agent/soliplex_agent.dart'
+    show AgentRuntime, FormApi, RuntimeAgentApi;
 import 'package:soliplex_client/soliplex_client.dart' show ToolCallInfo;
 import 'package:soliplex_dataframe/soliplex_dataframe.dart';
 import 'package:soliplex_frontend/core/providers/api_provider.dart';
 import 'package:soliplex_frontend/core/providers/flutter_host_api.dart';
 import 'package:soliplex_frontend/features/debug/debug_chart_config.dart';
 import 'package:soliplex_frontend/features/debug/debug_chart_renderer.dart';
+import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_scripting/soliplex_scripting.dart';
-
-// ---------------------------------------------------------------------------
-// Demo step definitions
-// ---------------------------------------------------------------------------
-
-class _DemoStep {
-  const _DemoStep({
-    required this.title,
-    required this.narration,
-    required this.code,
-    this.expectsError = false,
-  });
-
-  final String title;
-  final String narration;
-  final String code;
-  final bool expectsError;
-}
-
-const _demos = <(String name, String description, List<_DemoStep> steps)>[
-  (
-    'Error Recovery',
-    'Demonstrates the retry loop: code fails, gets fixed, succeeds.',
-    [
-      _DemoStep(
-        title: 'Step 1: Buggy code',
-        narration: 'The LLM writes code with a typo — pritn instead of print.',
-        code: 'pritn("hello world")',
-        expectsError: true,
-      ),
-      _DemoStep(
-        title: 'Step 2: LLM reads the error, fixes the typo',
-        narration: 'Monty reported NameError. The LLM corrects pritn → print.',
-        code: 'print("hello world")',
-      ),
-    ],
-  ),
-  (
-    'DataFrame → Chart',
-    'Creates a DataFrame, computes stats, and renders a bar chart.',
-    [
-      _DemoStep(
-        title: 'Step 1: Create DataFrame',
-        narration: 'Python creates a DataFrame with city population data.',
-        code: '''
-handle = df_create([
-    {"city": "Tokyo", "population": 37.4, "continent": "Asia"},
-    {"city": "Delhi", "population": 32.9, "continent": "Asia"},
-    {"city": "Shanghai", "population": 28.5, "continent": "Asia"},
-    {"city": "São Paulo", "population": 22.4, "continent": "S. America"},
-    {"city": "Mexico City", "population": 21.8, "continent": "N. America"}
-])
-print(f"Created DataFrame handle={handle}")
-shape = df_shape(handle)
-print(f"Shape: {shape[0]} rows x {shape[1]} columns")
-head = df_head(handle, 5)
-for row in head:
-    print(row)
-''',
-      ),
-      _DemoStep(
-        title: 'Step 2: Render bar chart',
-        narration:
-            'Now we visualize the data as a bar chart in the Flutter UI.',
-        code: '''
-chart_create({
-    "type": "bar",
-    "title": "World Largest Cities by Population (millions)",
-    "labels": ["Tokyo", "Delhi", "Shanghai", "São Paulo", "Mexico City"],
-    "values": [37.4, 32.9, 28.5, 22.4, 21.8]
-})
-print("Chart rendered!")
-''',
-      ),
-    ],
-  ),
-  (
-    'Scatter Plot from Computation',
-    'Python computes mathematical data and charts it.',
-    [
-      _DemoStep(
-        title: 'Step 1: Compute data',
-        narration: 'Python generates x² values and creates a scatter plot.',
-        code: '''
-points = []
-for x in range(1, 16):
-    y = (x ** 0.5) * 10
-    points.append([x, round(y, 1)])
-    print(f"x={x}, y={round(y, 1)}")
-
-chart_create({
-    "type": "scatter",
-    "title": "Square Root Curve (√x × 10)",
-    "x_label": "x",
-    "y_label": "√x × 10",
-    "points": points
-})
-print(f"Plotted {len(points)} points")
-''',
-      ),
-    ],
-  ),
-  (
-    'Multi-Step Analysis',
-    'Create, filter, sort, and chart — a realistic analysis workflow.',
-    [
-      _DemoStep(
-        title: 'Step 1: Create sales dataset',
-        narration:
-            'Build a sales DataFrame with regions and quarterly revenue.',
-        code: '''
-h = df_create([
-    {"region": "North", "quarter": "Q1", "revenue": 120},
-    {"region": "South", "quarter": "Q1", "revenue": 95},
-    {"region": "East", "quarter": "Q1", "revenue": 140},
-    {"region": "West", "quarter": "Q1", "revenue": 88},
-    {"region": "North", "quarter": "Q2", "revenue": 135},
-    {"region": "South", "quarter": "Q2", "revenue": 102},
-    {"region": "East", "quarter": "Q2", "revenue": 155},
-    {"region": "West", "quarter": "Q2", "revenue": 91}
-])
-print(f"Sales data created (handle={h})")
-rows = df_head(h, 8)
-for r in rows:
-    print(r)
-''',
-      ),
-      _DemoStep(
-        title: 'Step 2: Filter Q2 and chart',
-        narration: 'Filter to Q2 only, then chart regional revenue.',
-        code: '''
-h = 1
-q2 = df_filter(h, "quarter", "==", "Q2")
-print(f"Filtered to Q2 (handle={q2})")
-q2_rows = df_head(q2, 4)
-regions = []
-revenues = []
-for r in q2_rows:
-    regions.append(r["region"])
-    revenues.append(r["revenue"])
-    print(r)
-
-chart_create({
-    "type": "bar",
-    "title": "Q2 Revenue by Region",
-    "labels": regions,
-    "values": revenues
-})
-print("Q2 chart rendered!")
-''',
-      ),
-      _DemoStep(
-        title: 'Step 3: Growth line chart',
-        narration: 'Compute Q1→Q2 growth per region and plot as a line chart.',
-        code: '''
-points = []
-regions = ["North", "South", "East", "West"]
-q1_vals = [120, 95, 140, 88]
-q2_vals = [135, 102, 155, 91]
-for i in range(4):
-    pct = (q2_vals[i] - q1_vals[i]) / q1_vals[i] * 100
-    points.append([i + 1, pct])
-    print(f"{regions[i]}: {q1_vals[i]} -> {q2_vals[i]} = +{pct:.1f}%")
-
-chart_create({
-    "type": "line",
-    "title": "Q1 -> Q2 Revenue Growth %",
-    "x_label": "Region (1=N, 2=S, 3=E, 4=W)",
-    "y_label": "Growth %",
-    "points": points
-})
-print("Growth chart rendered!")
-''',
-      ),
-    ],
-  ),
-];
+import 'package:soliplex_showcase/soliplex_showcase.dart';
 
 // ---------------------------------------------------------------------------
 // Screen
@@ -208,37 +36,132 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
 
   late final BridgeCache _bridgeCache;
   late final MontyToolExecutor _executor;
-  late final DfRegistry _registry;
-  final _charts = <DebugChartConfig>[];
+  late final DfRegistry _dfRegistry;
+  late final StreamRegistry _streamRegistry;
+  final _charts = <int, DebugChartConfig>{};
   final _log = <_LogEntry>[];
   int _selectedDemo = 0;
   int _currentStep = 0;
   bool _isRunning = false;
   bool _autoPlay = false;
 
+  // Drawing canvas state (Demo 10)
+  final _drawingGrid = DrawingGrid();
+  StreamController<Object?>? _drawingController;
+
+  // Form state (Demo 11)
+  final _formApi = _ShowcaseFormApi();
+  StreamController<Object?>? _formController;
+
+  // Tic-Tac-Toe state (Demo 12)
+  final _tttGrid = TicTacToeGrid();
+  StreamController<Object?>? _tttController;
+
   @override
   void initState() {
     super.initState();
     _bridgeCache = ref.read(bridgeCacheProvider);
+    _streamRegistry = StreamRegistry();
+    _initExecutor();
+  }
+
+  void _initExecutor() {
     final (:hostApi, :dfRegistry) = createFlutterHostBundle(
-      onChartCreated: (_, config) {
-        setState(() => _charts.add(config));
+      onChartCreated: (id, config) {
+        setState(() => _charts[id] = config);
+      },
+      onChartUpdated: (id, config) {
+        setState(() => _charts[id] = config);
       },
     );
-    _registry = dfRegistry;
+    _dfRegistry = dfRegistry;
+
+    // Register stream factories.
+    _streamRegistry
+      ..registerFactory('radar_metrics', radarMetricsStream)
+      ..registerFactory('market_share', marketShareStream)
+      ..registerFactory('server_metrics', serverMetricsStream);
+    _registerUserInputStreams();
+
+    // Create AgentRuntime for ask_llm support.
+    final runtime = AgentRuntime(
+      api: ref.read(apiProvider),
+      agUiClient: ref.read(agUiClientProvider),
+      toolRegistryResolver: (roomId) async => ref.read(toolRegistryProvider),
+      platform: ref.read(platformConstraintsProvider),
+      logger: LogManager.instance.getLogger('MontyShowcase'),
+    );
+
     _executor = MontyToolExecutor(
       threadKey: _threadKey,
       bridgeCache: _bridgeCache,
       hostWiring: HostFunctionWiring(
         hostApi: hostApi,
         dfRegistry: dfRegistry,
+        streamRegistry: _streamRegistry,
+        formApi: _formApi,
+        agentApi: RuntimeAgentApi(runtime: runtime),
+        extraFunctions: [
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'ttt_move',
+              description: 'Place a mark on the tic-tac-toe grid.',
+              params: [
+                HostParam(
+                  name: 'cell',
+                  type: HostParamType.integer,
+                  description: 'Cell index (0-8).',
+                ),
+                HostParam(
+                  name: 'player',
+                  type: HostParamType.string,
+                  description: 'Player mark: "X" or "O".',
+                ),
+              ],
+            ),
+            handler: (args) async {
+              final cell = (args['cell']! as num).toInt();
+              final player = args['player']! as String;
+              _tttGrid.play(cell, player);
+              setState(() {});
+              return null;
+            },
+          ),
+        ],
       ),
+    );
+  }
+
+  void _registerUserInputStreams() {
+    _drawingController?.close();
+    _drawingController = StreamController<Object?>();
+    _streamRegistry.registerFactory(
+      'drawing_input',
+      () => _drawingController!.stream,
+    );
+
+    _formController?.close();
+    _formController = StreamController<Object?>();
+    _streamRegistry.registerFactory(
+      'form_submissions',
+      () => _formController!.stream,
+    );
+
+    _tttController?.close();
+    _tttController = StreamController<Object?>();
+    _streamRegistry.registerFactory(
+      'ttt_input',
+      () => _tttController!.stream,
     );
   }
 
   @override
   void dispose() {
-    _registry.disposeAll();
+    _dfRegistry.disposeAll();
+    _streamRegistry.dispose();
+    _drawingController?.close();
+    _formController?.close();
+    _tttController?.close();
     _bridgeCache.evict(_threadKey);
     super.dispose();
   }
@@ -246,14 +169,18 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final (name, description, steps) = _demos[_selectedDemo];
+    const demos = ShowcaseDemoRegistry.demos;
+    final demo = demos[_selectedDemo];
 
     return Column(
       children: [
         // Demo selector bar
         Container(
           width: double.infinity,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 8,
+          ),
           color: theme.colorScheme.surfaceContainerHighest,
           child: Row(
             children: [
@@ -262,9 +189,9 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                   spacing: 8,
                   runSpacing: 4,
                   children: [
-                    for (var i = 0; i < _demos.length; i++)
+                    for (var i = 0; i < demos.length; i++)
                       ChoiceChip(
-                        label: Text(_demos[i].$1),
+                        label: Text(demos[i].name),
                         selected: i == _selectedDemo,
                         onSelected: _isRunning
                             ? null
@@ -296,7 +223,7 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
           child: Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              description,
+              demo.description,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -309,15 +236,30 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Left: Steps + code
+              // Left: Steps + code + interactive widgets
               Expanded(
                 flex: 3,
                 child: ListView(
                   padding: const EdgeInsets.all(16),
                   children: [
-                    for (var i = 0; i < steps.length; i++) ...[
-                      _buildStepCard(i, steps[i]),
-                      if (i < steps.length - 1) const SizedBox(height: 12),
+                    for (var i = 0; i < demo.steps.length; i++) ...[
+                      _buildStepCard(i, demo.steps[i]),
+                      if (i < demo.steps.length - 1) const SizedBox(height: 12),
+                    ],
+                    // Drawing canvas for Demo 10
+                    if (_isDrawingDemo) ...[
+                      const SizedBox(height: 16),
+                      _buildDrawingCanvas(theme),
+                    ],
+                    // Form for Demo 11
+                    if (_isFormDemo) ...[
+                      const SizedBox(height: 16),
+                      _buildFormWidget(theme),
+                    ],
+                    // Tic-Tac-Toe grid for Demo 12
+                    if (_isTttDemo) ...[
+                      const SizedBox(height: 16),
+                      _buildTicTacToeWidget(theme),
                     ],
                   ],
                 ),
@@ -335,15 +277,21 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                         height: 220,
                         child: PageView.builder(
                           itemCount: _charts.length,
-                          itemBuilder: (_, i) => Padding(
-                            padding: const EdgeInsets.all(12),
-                            child: DebugChartRenderer(config: _charts[i]),
-                          ),
+                          itemBuilder: (_, i) {
+                            final config = _charts.values.elementAt(i);
+                            return Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: DebugChartRenderer(
+                                config: config,
+                              ),
+                            );
+                          },
                         ),
                       ),
                       Center(
                         child: Text(
-                          '${_charts.length} chart(s) — swipe to browse',
+                          '${_charts.length} chart(s) — '
+                          'swipe to browse',
                           style: theme.textTheme.bodySmall,
                         ),
                       ),
@@ -359,7 +307,12 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                     ),
                     Expanded(
                       child: Container(
-                        margin: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                        margin: const EdgeInsets.fromLTRB(
+                          12,
+                          0,
+                          12,
+                          12,
+                        ),
                         decoration: BoxDecoration(
                           color: const Color(0xFF1E1E1E),
                           borderRadius: BorderRadius.circular(8),
@@ -386,7 +339,201 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
     );
   }
 
-  Widget _buildStepCard(int index, _DemoStep step) {
+  // Demo 10 = "Drawing Recognition" (index 9)
+  bool get _isDrawingDemo => _selectedDemo == 9;
+
+  // Demo 11 = "Form Validation" (index 10)
+  bool get _isFormDemo => _selectedDemo == 10;
+
+  // Demo 12 = "Tic-Tac-Toe" (index 11)
+  bool get _isTttDemo => _selectedDemo == 11;
+
+  Widget _buildDrawingCanvas(ThemeData theme) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Drawing Canvas (20x20)',
+              style: theme.textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            AspectRatio(
+              aspectRatio: 1,
+              child: LayoutBuilder(
+                builder: (context, constraints) => GestureDetector(
+                  onPanUpdate: (details) {
+                    final local = details.localPosition;
+                    final col =
+                        (local.dx / constraints.maxWidth * DrawingGrid.size)
+                            .floor();
+                    final row =
+                        (local.dy / constraints.maxHeight * DrawingGrid.size)
+                            .floor();
+                    _drawingGrid.setCell(row, col);
+                    setState(() {});
+                  },
+                  child: CustomPaint(
+                    painter: _DrawingGridPainter(
+                      grid: _drawingGrid,
+                      color: theme.colorScheme.primary,
+                    ),
+                    size: Size.infinite,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                FilledButton(
+                  onPressed: () {
+                    _drawingController?.add(
+                      _drawingGrid.toAscii(),
+                    );
+                  },
+                  child: const Text('Submit Drawing'),
+                ),
+                const SizedBox(width: 8),
+                OutlinedButton(
+                  onPressed: () {
+                    _drawingGrid.clear();
+                    setState(() {});
+                  },
+                  child: const Text('Clear'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFormWidget(ThemeData theme) {
+    final fields = _formApi.currentFields;
+    final errors = _formApi.currentErrors;
+    if (fields.isEmpty) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(
+            'Run the demo to create a form.',
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Dynamic Form',
+              style: theme.textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            for (final field in fields) ...[
+              TextField(
+                decoration: InputDecoration(
+                  labelText:
+                      field['label'] as String? ?? field['name'] as String?,
+                  errorText: errors[field['name'] as String?],
+                ),
+                onChanged: (value) {
+                  final name = field['name'] as String?;
+                  if (name != null) {
+                    _formApi.formData[name] = value;
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+            FilledButton(
+              onPressed: () {
+                _formController?.add(
+                  Map<String, Object?>.from(_formApi.formData),
+                );
+              },
+              child: const Text('Submit Form'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTicTacToeWidget(ThemeData theme) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Tic-Tac-Toe (tap a cell to play X)',
+              style: theme.textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: 200,
+              height: 200,
+              child: GridView.count(
+                crossAxisCount: 3,
+                physics: const NeverScrollableScrollPhysics(),
+                children: [
+                  for (var i = 0; i < 9; i++)
+                    InkWell(
+                      onTap: () {
+                        if (_tttGrid.getCell(i) == '') {
+                          _tttGrid.play(i, 'X');
+                          _tttController?.add(i);
+                          setState(() {});
+                        }
+                      },
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: theme.colorScheme.outline,
+                          ),
+                        ),
+                        alignment: Alignment.center,
+                        child: Text(
+                          _tttGrid.getCell(i),
+                          style: TextStyle(
+                            fontSize: 32,
+                            fontWeight: FontWeight.bold,
+                            color: _tttGrid.getCell(i) == 'X'
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.error,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: () {
+                _tttGrid.reset();
+                _registerUserInputStreams();
+                setState(() {});
+              },
+              child: const Text('New Game'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStepCard(int index, ShowcaseDemoStep step) {
     final theme = Theme.of(context);
     final isDone = _stepResults.containsKey(index);
     final isActive = index == _currentStep && _isRunning;
@@ -412,7 +559,9 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                   const SizedBox(
                     width: 16,
                     height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                    ),
                   )
                 else if (isDone && !(result?.isError ?? false))
                   const Icon(
@@ -421,7 +570,11 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                     size: 18,
                   )
                 else if (isDone && (result?.isError ?? false))
-                  const Icon(Icons.error, color: Colors.orange, size: 18)
+                  const Icon(
+                    Icons.error,
+                    color: Colors.orange,
+                    size: 18,
+                  )
                 else
                   Icon(
                     Icons.circle_outlined,
@@ -470,6 +623,17 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
                 ),
               ),
             ),
+            if (!_isRunning && !isDone) ...[
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: FilledButton.icon(
+                  onPressed: () => _runStep(index),
+                  icon: const Icon(Icons.play_arrow, size: 18),
+                  label: const Text('Run'),
+                ),
+              ),
+            ],
             if (result != null) ...[
               const SizedBox(height: 8),
               Container(
@@ -531,9 +695,9 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
     );
   }
 
-  // -------------------------------------------------------------------------
+  // -----------------------------------------------------------------------
   // Execution
-  // -------------------------------------------------------------------------
+  // -----------------------------------------------------------------------
 
   final _stepResults = <int, _StepResult>{};
 
@@ -544,8 +708,12 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
       _stepResults.clear();
       _log.clear();
       _charts.clear();
+      _formApi.reset();
+      _drawingGrid.clear();
+      _tttGrid.reset();
     });
-    _registry.disposeAll();
+    _dfRegistry.disposeAll();
+    _registerUserInputStreams();
   }
 
   void _reset() {
@@ -554,8 +722,12 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
       _stepResults.clear();
       _log.clear();
       _charts.clear();
+      _formApi.reset();
+      _drawingGrid.clear();
+      _tttGrid.reset();
     });
-    _registry.disposeAll();
+    _dfRegistry.disposeAll();
+    _registerUserInputStreams();
   }
 
   Future<void> _runAllSteps() async {
@@ -564,12 +736,14 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
       _autoPlay = true;
       _isRunning = true;
     });
-    final (_, _, steps) = _demos[_selectedDemo];
+    final steps = ShowcaseDemoRegistry.demos[_selectedDemo].steps;
     for (var i = 0; i < steps.length; i++) {
       if (!mounted) return;
       await _runStep(i);
       if (i < steps.length - 1) {
-        await Future<void>.delayed(const Duration(milliseconds: 800));
+        await Future<void>.delayed(
+          const Duration(milliseconds: 800),
+        );
       }
     }
     setState(() {
@@ -579,7 +753,7 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
   }
 
   Future<void> _runStep(int index) async {
-    final (_, _, steps) = _demos[_selectedDemo];
+    final steps = ShowcaseDemoRegistry.demos[_selectedDemo].steps;
     final step = steps[index];
 
     setState(() {
@@ -599,13 +773,15 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
       final output = await _executor.execute(toolCall);
 
       if (step.expectsError) {
-        // Shouldn't get here for expected errors, but handle gracefully
         _addLog(output, _LogKind.output);
         setState(() {
           _stepResults[index] = _StepResult(output);
         });
       } else {
-        _addLog(output.isEmpty ? '(no output)' : output, _LogKind.output);
+        _addLog(
+          output.isEmpty ? '(no output)' : output,
+          _LogKind.output,
+        );
         setState(() {
           _stepResults[index] = _StepResult(
             output.isEmpty ? '(completed successfully)' : output,
@@ -616,7 +792,10 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
       final msg = '$e';
       _addLog(msg, _LogKind.error);
       setState(() {
-        _stepResults[index] = _StepResult(msg, isError: step.expectsError);
+        _stepResults[index] = _StepResult(
+          msg,
+          isError: step.expectsError,
+        );
       });
       if (step.expectsError) {
         _addLog(
@@ -633,6 +812,88 @@ class _MontyShowcaseScreenState extends ConsumerState<MontyShowcaseScreen> {
 
   void _addLog(String text, _LogKind kind) {
     setState(() => _log.add(_LogEntry(text, kind)));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Drawing grid painter
+// ---------------------------------------------------------------------------
+
+class _DrawingGridPainter extends CustomPainter {
+  _DrawingGridPainter({required this.grid, required this.color});
+
+  final DrawingGrid grid;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final cellW = size.width / DrawingGrid.size;
+    final cellH = size.height / DrawingGrid.size;
+    final fillPaint = Paint()..color = color;
+    final gridPaint = Paint()
+      ..color = color.withValues(alpha: 0.2)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 0.5;
+
+    for (var r = 0; r < DrawingGrid.size; r++) {
+      for (var c = 0; c < DrawingGrid.size; c++) {
+        final rect = Rect.fromLTWH(
+          c * cellW,
+          r * cellH,
+          cellW,
+          cellH,
+        );
+        canvas.drawRect(rect, gridPaint);
+        if (grid.getCell(r, c)) {
+          canvas.drawRect(rect, fillPaint);
+        }
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DrawingGridPainter old) => true;
+}
+
+// ---------------------------------------------------------------------------
+// Showcase FormApi implementation
+// ---------------------------------------------------------------------------
+
+class _ShowcaseFormApi implements FormApi {
+  final forms = <int, List<Map<String, Object?>>>{};
+  final errors = <int, Map<String, String>>{};
+  final formData = <String, Object?>{};
+  int _nextId = 1;
+
+  List<Map<String, Object?>> get currentFields {
+    if (forms.isEmpty) return [];
+    return forms.values.last;
+  }
+
+  Map<String, String> get currentErrors {
+    if (errors.isEmpty) return {};
+    return errors.values.last;
+  }
+
+  void reset() {
+    forms.clear();
+    errors.clear();
+    formData.clear();
+    _nextId = 1;
+  }
+
+  @override
+  int createForm(List<Map<String, Object?>> fields) {
+    final id = _nextId++;
+    forms[id] = fields;
+    return id;
+  }
+
+  @override
+  bool setFormErrors(int handle, Map<String, String> fieldErrors) {
+    if (!forms.containsKey(handle)) return false;
+    errors[handle] = fieldErrors;
+    return true;
   }
 }
 

--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -33,6 +33,7 @@ export 'src/client_bundle.dart';
 export 'src/host/agent_api.dart';
 export 'src/host/fake_agent_api.dart';
 export 'src/host/fake_host_api.dart';
+export 'src/host/form_api.dart';
 export 'src/host/host_api.dart';
 export 'src/host/native_platform_constraints.dart';
 export 'src/host/platform_constraints.dart';

--- a/packages/soliplex_agent/lib/src/host/agent_api.dart
+++ b/packages/soliplex_agent/lib/src/host/agent_api.dart
@@ -6,8 +6,14 @@
 abstract interface class AgentApi {
   /// Spawns a new agent in [roomId] with the given [prompt].
   ///
+  /// If [threadId] is provided, continues an existing conversation thread.
   /// Returns an integer handle for tracking the agent session.
-  Future<int> spawnAgent(String roomId, String prompt, {Duration? timeout});
+  Future<int> spawnAgent(
+    String roomId,
+    String prompt, {
+    String? threadId,
+    Duration? timeout,
+  });
 
   /// Waits for all agents identified by [handles] to complete.
   ///
@@ -16,6 +22,9 @@ abstract interface class AgentApi {
 
   /// Returns the output text for a completed agent [handle].
   Future<String> getResult(int handle, {Duration? timeout});
+
+  /// Returns the thread ID for a given agent [handle].
+  String getThreadId(int handle);
 
   /// Cancels the agent identified by [handle].
   ///

--- a/packages/soliplex_agent/lib/src/host/fake_agent_api.dart
+++ b/packages/soliplex_agent/lib/src/host/fake_agent_api.dart
@@ -28,15 +28,22 @@ class FakeAgentApi implements AgentApi {
   /// Recorded calls as `{methodName: [args]}`.
   final Map<String, List<Object?>> calls = {};
 
+  /// Thread ID returned by [getThreadId].
+  String threadIdResult = 'fake-thread-id';
+
   @override
   Future<int> spawnAgent(
     String roomId,
     String prompt, {
+    String? threadId,
     Duration? timeout,
   }) async {
-    calls['spawnAgent'] = [roomId, prompt, timeout];
+    calls['spawnAgent'] = [roomId, prompt, threadId, timeout];
     return spawnResult++;
   }
+
+  @override
+  String getThreadId(int handle) => threadIdResult;
 
   @override
   Future<List<String>> waitAll(List<int> handles, {Duration? timeout}) async {

--- a/packages/soliplex_agent/lib/src/host/fake_host_api.dart
+++ b/packages/soliplex_agent/lib/src/host/fake_host_api.dart
@@ -44,6 +44,13 @@ class FakeHostApi implements HostApi {
   }
 
   @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) {
+    if (!_charts.containsKey(chartId)) return false;
+    _charts[chartId] = Map.unmodifiable(chartConfig);
+    return true;
+  }
+
+  @override
   Future<Object?> invoke(String name, Map<String, Object?> args) async {
     final handler = invokeHandler;
     if (handler == null) {

--- a/packages/soliplex_agent/lib/src/host/form_api.dart
+++ b/packages/soliplex_agent/lib/src/host/form_api.dart
@@ -1,0 +1,17 @@
+/// Interface for form operations exposed to the scripting layer.
+///
+/// Python code can create forms and set validation errors via
+/// host functions that delegate to this interface.
+abstract interface class FormApi {
+  /// Create a dynamic form with the given field definitions.
+  ///
+  /// Each entry in [fields] is a map with keys like `name`, `label`, `type`.
+  /// Returns an integer handle for the form.
+  int createForm(List<Map<String, Object?>> fields);
+
+  /// Set validation errors on a form.
+  ///
+  /// [errors] maps field names to error messages.
+  /// Returns `true` if the form existed and errors were set.
+  bool setFormErrors(int handle, Map<String, String> errors);
+}

--- a/packages/soliplex_agent/lib/src/host/host_api.dart
+++ b/packages/soliplex_agent/lib/src/host/host_api.dart
@@ -24,6 +24,11 @@ abstract interface class HostApi {
   /// Returns an integer handle for later retrieval.
   int registerChart(Map<String, Object?> chartConfig);
 
+  /// Update an existing chart with a new configuration.
+  ///
+  /// Returns `true` if the chart existed and was updated, `false` otherwise.
+  bool updateChart(int chartId, Map<String, Object?> chartConfig);
+
   // ── Platform services + extensibility ────────────────────────────
 
   /// Invoke a host operation by namespaced name.

--- a/packages/soliplex_agent/lib/src/host/runtime_agent_api.dart
+++ b/packages/soliplex_agent/lib/src/host/runtime_agent_api.dart
@@ -21,17 +21,23 @@ class RuntimeAgentApi implements AgentApi {
   Future<int> spawnAgent(
     String roomId,
     String prompt, {
+    String? threadId,
     Duration? timeout,
   }) async {
     final session = await _runtime.spawn(
       roomId: roomId,
       prompt: prompt,
+      threadId: threadId,
       timeout: timeout,
+      ephemeral: false,
     );
     final handle = _nextHandle++;
     _handles[handle] = session;
     return handle;
   }
+
+  @override
+  String getThreadId(int handle) => _lookupSession(handle).threadKey.threadId;
 
   @override
   Future<List<String>> waitAll(List<int> handles, {Duration? timeout}) async {

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/default_monty_bridge.dart
@@ -37,12 +37,17 @@ class _PendingFuture {
 /// Orchestrates the Monty start/resume loop, dispatching external function
 /// calls to registered [HostFunction] handlers and emitting [BridgeEvent]s.
 class DefaultMontyBridge implements MontyBridge {
-  DefaultMontyBridge({MontyPlatform? platform, MontyLimits? limits})
-      : _explicitPlatform = platform,
-        _limits = limits;
+  DefaultMontyBridge({
+    MontyPlatform? platform,
+    MontyLimits? limits,
+    bool useFutures = true,
+  })  : _explicitPlatform = platform,
+        _limits = limits,
+        _useFutures = useFutures;
 
   final MontyPlatform? _explicitPlatform;
   final MontyLimits? _limits;
+  final bool _useFutures;
   final Map<String, HostFunction> _functions = {};
   final Map<int, _PendingFuture> _pendingFutures = {};
   int _idCounter = 0;
@@ -105,7 +110,7 @@ class DefaultMontyBridge implements MontyBridge {
     final printBuffer = StringBuffer();
     final wrappedCode = '$_printPreamble\n$code';
     final externalFunctions = [_consoleWriteFn, ..._functions.keys];
-    final futuresCapable = _platform is MontyFutureCapable;
+    final futuresCapable = _useFutures && _platform is MontyFutureCapable;
 
     _pendingFutures.clear();
 

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/host_param.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/host_param.dart
@@ -45,7 +45,7 @@ class HostParam {
 
     return switch (type) {
       HostParamType.string => _expectType<String>(value),
-      HostParamType.integer => _expectType<int>(value),
+      HostParamType.integer => _coerceInt(value),
       HostParamType.number => _coerceNumber(value),
       HostParamType.boolean => _expectType<bool>(value),
       HostParamType.list => _expectType<List<Object?>>(value),
@@ -62,9 +62,27 @@ class HostParam {
     );
   }
 
+  /// Accept int, num, or numeric string for integer params.
+  int _coerceInt(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) {
+      final parsed = int.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+    throw FormatException(
+      'Parameter "$name": expected int, got ${value.runtimeType}',
+      value,
+    );
+  }
+
   /// Accept both int and double for number params.
   num _coerceNumber(Object? value) {
     if (value is num) return value;
+    if (value is String) {
+      final parsed = num.tryParse(value);
+      if (parsed != null) return parsed;
+    }
     throw FormatException(
       'Parameter "$name": expected num, got ${value.runtimeType}',
       value,

--- a/packages/soliplex_scripting/lib/soliplex_scripting.dart
+++ b/packages/soliplex_scripting/lib/soliplex_scripting.dart
@@ -3,6 +3,9 @@ library;
 
 export 'package:soliplex_agent/soliplex_agent.dart' show ThreadKey;
 
+export 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart'
+    show HostFunction, HostFunctionSchema, HostParam, HostParamType;
+
 export 'src/ag_ui_bridge_adapter.dart';
 export 'src/bridge_cache.dart';
 export 'src/df_functions.dart';
@@ -11,3 +14,4 @@ export 'src/host_schema_ag_ui.dart';
 export 'src/monty_tool_executor.dart';
 export 'src/python_executor_tool.dart';
 export 'src/scripting_tool_registry_resolver.dart';
+export 'src/stream_registry.dart';

--- a/packages/soliplex_scripting/lib/src/bridge_cache.dart
+++ b/packages/soliplex_scripting/lib/src/bridge_cache.dart
@@ -63,7 +63,7 @@ class BridgeCache {
       _evictLru();
     }
 
-    final bridge = _factory?.call() ?? DefaultMontyBridge();
+    final bridge = _factory?.call() ?? DefaultMontyBridge(useFutures: false);
     _bridges[key] = bridge;
     _executing.add(key);
     return bridge;

--- a/packages/soliplex_scripting/lib/src/host_function_wiring.dart
+++ b/packages/soliplex_scripting/lib/src/host_function_wiring.dart
@@ -1,7 +1,9 @@
-import 'package:soliplex_agent/soliplex_agent.dart' show AgentApi, HostApi;
+import 'package:soliplex_agent/soliplex_agent.dart'
+    show AgentApi, FormApi, HostApi;
 import 'package:soliplex_dataframe/soliplex_dataframe.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:soliplex_scripting/src/df_functions.dart';
+import 'package:soliplex_scripting/src/stream_registry.dart';
 
 /// Wires [HostApi] methods to [HostFunction]s and registers them onto a
 /// [MontyBridge] via a [HostFunctionRegistry].
@@ -19,13 +21,22 @@ class HostFunctionWiring {
     required HostApi hostApi,
     AgentApi? agentApi,
     DfRegistry? dfRegistry,
+    StreamRegistry? streamRegistry,
+    FormApi? formApi,
+    List<HostFunction>? extraFunctions,
   })  : _hostApi = hostApi,
         _agentApi = agentApi,
-        _dfRegistry = dfRegistry ?? DfRegistry();
+        _dfRegistry = dfRegistry ?? DfRegistry(),
+        _streamRegistry = streamRegistry,
+        _formApi = formApi,
+        _extraFunctions = extraFunctions;
 
   final HostApi _hostApi;
   final AgentApi? _agentApi;
   final DfRegistry _dfRegistry;
+  final StreamRegistry? _streamRegistry;
+  final FormApi? _formApi;
+  final List<HostFunction>? _extraFunctions;
 
   /// Registers all host function categories (plus introspection builtins)
   /// onto [bridge].
@@ -34,8 +45,17 @@ class HostFunctionWiring {
       ..addCategory('df', buildDfFunctions(_dfRegistry))
       ..addCategory('chart', _chartFunctions())
       ..addCategory('platform', _platformFunctions());
+    if (_streamRegistry != null) {
+      registry.addCategory('stream', _streamFunctions());
+    }
+    if (_formApi != null) {
+      registry.addCategory('form', _formFunctions());
+    }
     if (_agentApi != null) {
       registry.addCategory('agent', _agentFunctions());
+    }
+    if (_extraFunctions != null && _extraFunctions.isNotEmpty) {
+      registry.addCategory('extra', _extraFunctions);
     }
     registry.registerAllOnto(bridge);
   }
@@ -59,6 +79,35 @@ class HostFunctionWiring {
               throw ArgumentError.value(raw, 'config', 'Expected a map.');
             }
             return _hostApi.registerChart(Map<String, Object?>.from(raw));
+          },
+        ),
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'chart_update',
+            description: 'Update an existing chart with a new configuration.',
+            params: [
+              HostParam(
+                name: 'chart_id',
+                type: HostParamType.integer,
+                description: 'Chart handle returned by chart_create.',
+              ),
+              HostParam(
+                name: 'config',
+                type: HostParamType.map,
+                description: 'New chart configuration.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final chartId = (args['chart_id']! as num).toInt();
+            final raw = args['config'];
+            if (raw is! Map) {
+              throw ArgumentError.value(raw, 'config', 'Expected a map.');
+            }
+            return _hostApi.updateChart(
+              chartId,
+              Map<String, Object?>.from(raw),
+            );
           },
         ),
       ];
@@ -91,6 +140,135 @@ class HostFunctionWiring {
               throw ArgumentError.value(rawArgs, 'args', 'Expected a map.');
             }
             return _hostApi.invoke(name, Map<String, Object?>.from(rawArgs));
+          },
+        ),
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'sleep',
+            description: 'Pause execution for a number of milliseconds.',
+            params: [
+              HostParam(
+                name: 'ms',
+                type: HostParamType.integer,
+                description: 'Duration in milliseconds.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final ms = (args['ms']! as num).toInt();
+            await Future<void>.delayed(Duration(milliseconds: ms));
+            return null;
+          },
+        ),
+      ];
+
+  List<HostFunction> _formFunctions() => [
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'form_create',
+            description: 'Create a dynamic form with field definitions.',
+            params: [
+              HostParam(
+                name: 'fields',
+                type: HostParamType.list,
+                description: 'List of field definition maps.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final raw = args['fields']! as List<Object?>;
+            final fields = <Map<String, Object?>>[];
+            for (final item in raw) {
+              fields.add(Map<String, Object?>.from(item! as Map));
+            }
+            return _formApi!.createForm(fields);
+          },
+        ),
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'form_set_errors',
+            description: 'Set validation errors on a form.',
+            params: [
+              HostParam(
+                name: 'handle',
+                type: HostParamType.integer,
+                description: 'Form handle.',
+              ),
+              HostParam(
+                name: 'errors',
+                type: HostParamType.map,
+                description: 'Map of field name to error message.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final handle = (args['handle']! as num).toInt();
+            final raw = args['errors'];
+            if (raw is! Map) {
+              throw ArgumentError.value(
+                raw,
+                'errors',
+                'Expected a map.',
+              );
+            }
+            return _formApi!.setFormErrors(
+              handle,
+              Map<String, String>.from(raw),
+            );
+          },
+        ),
+      ];
+
+  List<HostFunction> _streamFunctions() => [
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'stream_subscribe',
+            description: 'Subscribe to a named data stream.',
+            params: [
+              HostParam(
+                name: 'name',
+                type: HostParamType.string,
+                description: 'Stream name.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final name = args['name']! as String;
+            return _streamRegistry!.subscribe(name);
+          },
+        ),
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'stream_next',
+            description: 'Pull the next value from a stream subscription.',
+            params: [
+              HostParam(
+                name: 'handle',
+                type: HostParamType.integer,
+                description: 'Subscription handle.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final handle = (args['handle']! as num).toInt();
+            return _streamRegistry!.next(handle);
+          },
+        ),
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'stream_close',
+            description: 'Close a stream subscription early.',
+            params: [
+              HostParam(
+                name: 'handle',
+                type: HostParamType.integer,
+                description: 'Subscription handle.',
+              ),
+            ],
+          ),
+          handler: (args) async {
+            final handle = (args['handle']! as num).toInt();
+            return _streamRegistry!.close(handle);
           },
         ),
       ];
@@ -133,7 +311,7 @@ class HostFunctionWiring {
           ),
           handler: (args) async {
             final raw = args['handles']! as List<Object?>;
-            final handles = List<int>.from(raw);
+            final handles = raw.cast<num>().map((n) => n.toInt()).toList();
             return _agentApi!.waitAll(handles);
           },
         ),
@@ -150,14 +328,15 @@ class HostFunctionWiring {
             ],
           ),
           handler: (args) async {
-            final handle = args['handle']! as int;
+            final handle = (args['handle']! as num).toInt();
             return _agentApi!.getResult(handle);
           },
         ),
         HostFunction(
           schema: const HostFunctionSchema(
             name: 'ask_llm',
-            description: 'Spawn an agent and return its result in one call.',
+            description: 'Send a prompt to an LLM and return the response text '
+                'and thread ID. Pass thread_id to continue a conversation.',
             params: [
               HostParam(
                 name: 'prompt',
@@ -171,14 +350,27 @@ class HostFunctionWiring {
                 defaultValue: 'general',
                 description: 'Room ID (defaults to "general").',
               ),
+              HostParam(
+                name: 'thread_id',
+                type: HostParamType.string,
+                isRequired: false,
+                description: 'Thread ID to continue an existing conversation.',
+              ),
             ],
           ),
           handler: (args) async {
             final prompt = args['prompt']! as String;
             final room = args['room']! as String;
+            final threadId = args['thread_id'] as String?;
             final api = _agentApi!;
-            final handle = await api.spawnAgent(room, prompt);
-            return api.getResult(handle);
+            final handle = await api.spawnAgent(
+              room,
+              prompt,
+              threadId: threadId,
+            );
+            final tid = api.getThreadId(handle);
+            final result = await api.getResult(handle);
+            return <String, Object?>{'text': result, 'thread_id': tid};
           },
         ),
       ];

--- a/packages/soliplex_scripting/lib/src/stream_registry.dart
+++ b/packages/soliplex_scripting/lib/src/stream_registry.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+/// Manages named stream factories and active subscriptions.
+///
+/// Python code can subscribe to a named stream by calling
+/// [subscribe], pull values one at a time with [next], and
+/// close early with [close].
+///
+/// Each subscription gets a unique integer handle backed by a
+/// [StreamIterator] that lazily drains the factory-produced stream.
+class StreamRegistry {
+  final _factories = <String, Stream<Object?> Function()>{};
+  final _iterators = <int, StreamIterator<Object?>>{};
+  int _nextHandle = 1;
+
+  /// Register a named stream factory.
+  ///
+  /// The [factory] is invoked each time [subscribe] is called for [name],
+  /// producing a fresh stream per subscription.
+  void registerFactory(String name, Stream<Object?> Function() factory) {
+    _factories[name] = factory;
+  }
+
+  /// Subscribe to the named stream [name].
+  ///
+  /// Returns an integer handle for use with [next] and [close].
+  /// Throws [ArgumentError] if no factory is registered for [name].
+  int subscribe(String name) {
+    final factory = _factories[name];
+    if (factory == null) {
+      throw ArgumentError.value(name, 'name', 'No stream factory registered.');
+    }
+    final handle = _nextHandle++;
+    _iterators[handle] = StreamIterator(factory());
+    return handle;
+  }
+
+  /// Pull the next value from the subscription identified by [handle].
+  ///
+  /// Returns `null` when the stream is done (and automatically cleans up
+  /// the iterator). Throws [ArgumentError] for unknown handles.
+  Future<Object?> next(int handle) async {
+    final iterator = _iterators[handle];
+    if (iterator == null) {
+      throw ArgumentError.value(handle, 'handle', 'Unknown stream handle.');
+    }
+    if (await iterator.moveNext()) {
+      return iterator.current;
+    }
+    // Stream exhausted — clean up.
+    await iterator.cancel();
+    _iterators.remove(handle);
+    return null;
+  }
+
+  /// Close the subscription identified by [handle] early.
+  ///
+  /// Returns `true` if the handle existed and was closed, `false` otherwise.
+  Future<bool> close(int handle) async {
+    final iterator = _iterators.remove(handle);
+    if (iterator == null) return false;
+    await iterator.cancel();
+    return true;
+  }
+
+  /// Dispose all active subscriptions.
+  Future<void> dispose() async {
+    for (final iterator in _iterators.values) {
+      await iterator.cancel();
+    }
+    _iterators.clear();
+  }
+}

--- a/packages/soliplex_scripting/test/src/host_function_wiring_test.dart
+++ b/packages/soliplex_scripting/test/src/host_function_wiring_test.dart
@@ -51,6 +51,12 @@ class _FakeHostApi implements HostApi {
   }
 
   @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) {
+    calls['updateChart'] = [chartId, chartConfig];
+    return true;
+  }
+
+  @override
   Future<Object?> invoke(String name, Map<String, Object?> args) async {
     calls['invoke'] = [name, args];
     return 'invoked';
@@ -76,13 +82,15 @@ void main() {
       wiring.registerOnto(bridge);
 
       final names = bridge.registered.map((f) => f.schema.name).toSet();
-      // 37 df + 1 chart + 1 platform + 2 introspection = 41
-      expect(bridge.registered, hasLength(41));
+      // 37 df + 2 chart + 2 platform + 2 introspection = 43
+      expect(bridge.registered, hasLength(43));
       expect(names, contains('df_create'));
       expect(names, contains('df_head'));
       expect(names, contains('df_filter'));
       expect(names, contains('chart_create'));
+      expect(names, contains('chart_update'));
       expect(names, contains('host_invoke'));
+      expect(names, contains('sleep'));
       expect(names, contains('list_functions'));
       expect(names, contains('help'));
     });
@@ -163,8 +171,8 @@ void main() {
         expect(names, isNot(contains('ask_llm')));
         expect(
           b.registered,
-          hasLength(41),
-        ); // 37 df + 1 chart + 1 platform + 2 introspection
+          hasLength(43),
+        ); // 37 df + 2 chart + 2 platform + 2 introspection
       });
     });
   });
@@ -199,8 +207,8 @@ void main() {
           'ask_llm',
         ]),
       );
-      // 37 df + 1 chart + 1 platform + 4 agent + 2 introspection = 45
-      expect(bridge.registered, hasLength(45));
+      // 37 df + 2 chart + 2 platform + 4 agent + 2 introspection = 47
+      expect(bridge.registered, hasLength(47));
     });
 
     group('agent handler delegation', () {
@@ -222,7 +230,7 @@ void main() {
         expect(result, 10);
         expect(
           agentApi.calls['spawnAgent'],
-          ['weather', 'Is it raining?', null],
+          ['weather', 'Is it raining?', null, null],
         );
       });
 
@@ -253,8 +261,14 @@ void main() {
           'room': 'math',
         });
 
-        expect(result, 'agent output');
-        expect(agentApi.calls['spawnAgent'], ['math', 'What is 2+2?', null]);
+        expect(result, isA<Map<String, Object?>>());
+        final map = result! as Map<String, Object?>;
+        expect(map['text'], 'agent output');
+        expect(map['thread_id'], 'fake-thread-id');
+        expect(
+          agentApi.calls['spawnAgent'],
+          ['math', 'What is 2+2?', null, null],
+        );
         expect(agentApi.calls['getResult'], [10, null]);
       });
 
@@ -265,6 +279,16 @@ void main() {
         });
 
         expect(agentApi.calls['spawnAgent']![0], 'general');
+      });
+
+      test('ask_llm passes thread_id for continuity', () async {
+        await byName['ask_llm']!.handler({
+          'prompt': 'Continue',
+          'room': 'math',
+          'thread_id': 'tid-123',
+        });
+
+        expect(agentApi.calls['spawnAgent']![2], 'tid-123');
       });
 
       test('spawn_agent schema has correct params', () {
@@ -290,9 +314,9 @@ void main() {
         expect(schema.params[0].type, HostParamType.integer);
       });
 
-      test('ask_llm schema has string prompt and optional room', () {
+      test('ask_llm schema has prompt, room, and thread_id', () {
         final schema = byName['ask_llm']!.schema;
-        expect(schema.params, hasLength(2));
+        expect(schema.params, hasLength(3));
         expect(schema.params[0].name, 'prompt');
         expect(schema.params[0].type, HostParamType.string);
         expect(schema.params[0].isRequired, isTrue);
@@ -300,6 +324,9 @@ void main() {
         expect(schema.params[1].type, HostParamType.string);
         expect(schema.params[1].isRequired, isFalse);
         expect(schema.params[1].defaultValue, 'general');
+        expect(schema.params[2].name, 'thread_id');
+        expect(schema.params[2].type, HostParamType.string);
+        expect(schema.params[2].isRequired, isFalse);
       });
     });
   });

--- a/packages/soliplex_scripting/test/src/host_schema_ag_ui_test.dart
+++ b/packages/soliplex_scripting/test/src/host_schema_ag_ui_test.dart
@@ -1,5 +1,4 @@
 import 'package:ag_ui/ag_ui.dart' show Tool;
-import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:soliplex_scripting/soliplex_scripting.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_scripting/test/src/integration_test.dart
+++ b/packages/soliplex_scripting/test/src/integration_test.dart
@@ -36,6 +36,9 @@ class _FakeHostApi implements HostApi {
   }
 
   @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) => false;
+
+  @override
   Future<Object?> invoke(
     String name,
     Map<String, Object?> args,

--- a/packages/soliplex_scripting/test/src/monty_tool_executor_test.dart
+++ b/packages/soliplex_scripting/test/src/monty_tool_executor_test.dart
@@ -50,6 +50,9 @@ class _StubHostApi implements HostApi {
   int registerChart(Map<String, Object?> chartConfig) => 1;
 
   @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) => false;
+
+  @override
   Future<Object?> invoke(String name, Map<String, Object?> args) async => null;
 }
 
@@ -196,8 +199,8 @@ void main() {
         );
 
         await executor.execute(_toolCall('x = 1'));
-        // 37 df + 1 chart + 1 platform + 2 introspection = 41
-        expect(bridge.registered, hasLength(41));
+        // 37 df + 2 chart + 2 platform + 2 introspection = 43
+        expect(bridge.registered, hasLength(43));
       });
 
       test('releases bridge even on error', () async {

--- a/packages/soliplex_scripting/test/src/scripting_tool_registry_resolver_test.dart
+++ b/packages/soliplex_scripting/test/src/scripting_tool_registry_resolver_test.dart
@@ -19,6 +19,9 @@ class _StubHostApi implements HostApi {
   int registerChart(Map<String, Object?> chartConfig) => 1;
 
   @override
+  bool updateChart(int chartId, Map<String, Object?> chartConfig) => false;
+
+  @override
   Future<Object?> invoke(
     String name,
     Map<String, Object?> args,

--- a/packages/soliplex_scripting/test/src/stream_registry_test.dart
+++ b/packages/soliplex_scripting/test/src/stream_registry_test.dart
@@ -1,0 +1,114 @@
+import 'package:soliplex_scripting/soliplex_scripting.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StreamRegistry', () {
+    late StreamRegistry registry;
+
+    setUp(() {
+      registry = StreamRegistry();
+    });
+
+    tearDown(() async {
+      await registry.dispose();
+    });
+
+    test('subscribe + next yields values then null', () async {
+      registry.registerFactory(
+        'counter',
+        () => Stream.fromIterable([1, 2, 3]),
+      );
+
+      final handle = registry.subscribe('counter');
+      expect(handle, isPositive);
+
+      expect(await registry.next(handle), 1);
+      expect(await registry.next(handle), 2);
+      expect(await registry.next(handle), 3);
+      expect(await registry.next(handle), isNull);
+    });
+
+    test('close cancels early', () async {
+      registry.registerFactory(
+        'infinite',
+        () async* {
+          var i = 0;
+          while (true) {
+            yield i++;
+          }
+        },
+      );
+
+      final handle = registry.subscribe('infinite');
+      expect(await registry.next(handle), 0);
+      expect(await registry.next(handle), 1);
+
+      final closed = await registry.close(handle);
+      expect(closed, isTrue);
+
+      // Closing again returns false.
+      final closedAgain = await registry.close(handle);
+      expect(closedAgain, isFalse);
+    });
+
+    test('unknown handle throws ArgumentError', () async {
+      expect(
+        () => registry.next(999),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('subscribe with unknown name throws ArgumentError', () {
+      expect(
+        () => registry.subscribe('nonexistent'),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('dispose cancels all active subscriptions', () async {
+      registry
+        ..registerFactory(
+          'a',
+          () => Stream.fromIterable([1, 2, 3]),
+        )
+        ..registerFactory(
+          'b',
+          () => Stream.fromIterable([4, 5, 6]),
+        );
+
+      final h1 = registry.subscribe('a');
+      final h2 = registry.subscribe('b');
+
+      // Pull one value from each.
+      expect(await registry.next(h1), 1);
+      expect(await registry.next(h2), 4);
+
+      await registry.dispose();
+
+      // After dispose, handles are gone.
+      expect(
+        () => registry.next(h1),
+        throwsA(isA<ArgumentError>()),
+      );
+      expect(
+        () => registry.next(h2),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('multiple subscriptions to same factory are independent', () async {
+      registry.registerFactory(
+        'nums',
+        () => Stream.fromIterable([10, 20]),
+      );
+
+      final h1 = registry.subscribe('nums');
+      final h2 = registry.subscribe('nums');
+
+      expect(await registry.next(h1), 10);
+      expect(await registry.next(h2), 10);
+      expect(await registry.next(h1), 20);
+      expect(await registry.next(h2), 20);
+    });
+  });
+}

--- a/packages/soliplex_showcase/analysis_options.yaml
+++ b/packages/soliplex_showcase/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.10.0.0.yaml

--- a/packages/soliplex_showcase/lib/soliplex_showcase.dart
+++ b/packages/soliplex_showcase/lib/soliplex_showcase.dart
@@ -1,0 +1,8 @@
+/// Showcase demo definitions for the Soliplex Monty interpreter.
+library;
+
+export 'src/demo_registry.dart';
+export 'src/demo_step.dart';
+export 'src/drawing_grid.dart';
+export 'src/stream_factories.dart';
+export 'src/tic_tac_toe_grid.dart';

--- a/packages/soliplex_showcase/lib/src/demo_registry.dart
+++ b/packages/soliplex_showcase/lib/src/demo_registry.dart
@@ -1,0 +1,626 @@
+import 'package:soliplex_showcase/src/demo_step.dart';
+
+/// A single showcase demo definition.
+typedef ShowcaseDemo = ({
+  String name,
+  String description,
+  List<ShowcaseDemoStep> steps,
+});
+
+/// Registry of all showcase demos.
+///
+/// Each demo is a record of (name, description, steps).
+class ShowcaseDemoRegistry {
+  ShowcaseDemoRegistry._();
+
+  /// All available demos.
+  static const List<ShowcaseDemo> demos = [
+    _errorRecovery,
+    _dataFrameChart,
+    _scatterPlot,
+    _multiStepAnalysis,
+    _fakeStreamingGauges,
+    _streamGauges,
+    _pieChart,
+    _radarChart,
+    _heatmap,
+    _drawingRecognition,
+    _formValidation,
+    _ticTacToe,
+  ];
+
+  // ── Demo 1: Error Recovery ──────────────────────────────────────
+
+  static const ShowcaseDemo _errorRecovery = (
+    name: 'Error Recovery',
+    description:
+        'Demonstrates the retry loop: code fails, gets fixed, succeeds.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Buggy code',
+        narration: 'The LLM writes code with a typo — pritn instead of print.',
+        code: 'pritn("hello world")',
+        expectsError: true,
+      ),
+      ShowcaseDemoStep(
+        title: 'Step 2: LLM reads the error, fixes the typo',
+        narration: 'Monty reported NameError. The LLM corrects pritn → print.',
+        code: 'print("hello world")',
+      ),
+    ],
+  );
+
+  // ── Demo 2: DataFrame → Chart ──────────────────────────────────
+
+  static const ShowcaseDemo _dataFrameChart = (
+    name: 'DataFrame → Chart',
+    description:
+        'Creates a DataFrame, computes stats, and renders a bar chart.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Create DataFrame',
+        narration: 'Python creates a DataFrame with city population data.',
+        code: '''
+handle = df_create([
+    {"city": "Tokyo", "population": 37.4, "continent": "Asia"},
+    {"city": "Delhi", "population": 32.9, "continent": "Asia"},
+    {"city": "Shanghai", "population": 28.5, "continent": "Asia"},
+    {"city": "São Paulo", "population": 22.4, "continent": "S. America"},
+    {"city": "Mexico City", "population": 21.8, "continent": "N. America"}
+])
+print(f"Created DataFrame handle={handle}")
+shape = df_shape(handle)
+print(f"Shape: {shape[0]} rows x {shape[1]} columns")
+head = df_head(handle, 5)
+for row in head:
+    print(row)
+''',
+      ),
+      ShowcaseDemoStep(
+        title: 'Step 2: Render bar chart',
+        narration:
+            'Now we visualize the data as a bar chart in the Flutter UI.',
+        code: '''
+chart_create({
+    "type": "bar",
+    "title": "World Largest Cities by Population (millions)",
+    "labels": ["Tokyo", "Delhi", "Shanghai", "São Paulo", "Mexico City"],
+    "values": [37.4, 32.9, 28.5, 22.4, 21.8]
+})
+print("Chart rendered!")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 3: Scatter Plot ───────────────────────────────────────
+
+  static const ShowcaseDemo _scatterPlot = (
+    name: 'Scatter Plot',
+    description: 'Python computes mathematical data and charts it.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Compute data',
+        narration: 'Python generates √x values and creates a scatter plot.',
+        code: '''
+points = []
+for x in range(1, 16):
+    y = (x ** 0.5) * 10
+    points.append([x, round(y, 1)])
+    print(f"x={x}, y={round(y, 1)}")
+
+chart_create({
+    "type": "scatter",
+    "title": "Square Root Curve (√x × 10)",
+    "x_label": "x",
+    "y_label": "√x × 10",
+    "points": points
+})
+print(f"Plotted {len(points)} points")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 4: Multi-Step Analysis ────────────────────────────────
+
+  static const ShowcaseDemo _multiStepAnalysis = (
+    name: 'Multi-Step Analysis',
+    description:
+        'Create, filter, sort, and chart — a realistic analysis workflow.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Create sales dataset',
+        narration:
+            'Build a sales DataFrame with regions and quarterly revenue.',
+        code: '''
+h = df_create([
+    {"region": "North", "quarter": "Q1", "revenue": 120},
+    {"region": "South", "quarter": "Q1", "revenue": 95},
+    {"region": "East", "quarter": "Q1", "revenue": 140},
+    {"region": "West", "quarter": "Q1", "revenue": 88},
+    {"region": "North", "quarter": "Q2", "revenue": 135},
+    {"region": "South", "quarter": "Q2", "revenue": 102},
+    {"region": "East", "quarter": "Q2", "revenue": 155},
+    {"region": "West", "quarter": "Q2", "revenue": 91}
+])
+print(f"Sales data created (handle={h})")
+rows = df_head(h, 8)
+for r in rows:
+    print(r)
+''',
+      ),
+      ShowcaseDemoStep(
+        title: 'Step 2: Filter Q2 and chart',
+        narration: 'Filter to Q2 only, then chart regional revenue.',
+        code: '''
+h = 1
+q2 = df_filter(h, "quarter", "==", "Q2")
+print(f"Filtered to Q2 (handle={q2})")
+q2_rows = df_head(q2, 4)
+regions = []
+revenues = []
+for r in q2_rows:
+    regions.append(r["region"])
+    revenues.append(r["revenue"])
+    print(r)
+
+chart_create({
+    "type": "bar",
+    "title": "Q2 Revenue by Region",
+    "labels": regions,
+    "values": revenues
+})
+print("Q2 chart rendered!")
+''',
+      ),
+      ShowcaseDemoStep(
+        title: 'Step 3: Growth line chart',
+        narration: 'Compute Q1→Q2 growth per region and plot as a line chart.',
+        code: '''
+points = []
+regions = ["North", "South", "East", "West"]
+q1_vals = [120, 95, 140, 88]
+q2_vals = [135, 102, 155, 91]
+for i in range(4):
+    pct = (q2_vals[i] - q1_vals[i]) / q1_vals[i] * 100
+    points.append([i + 1, pct])
+    print(regions[i] + ": " + str(q1_vals[i]) + " -> " + str(q2_vals[i]) + " = +" + str(round(pct * 10) / 10) + "%")
+
+chart_create({
+    "type": "line",
+    "title": "Q1 -> Q2 Revenue Growth %",
+    "x_label": "Region (1=N, 2=S, 3=E, 4=W)",
+    "y_label": "Growth %",
+    "points": points
+})
+print("Growth chart rendered!")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 5: Fake Streaming Gauges ─────────────────────────────
+
+  static const ShowcaseDemo _fakeStreamingGauges = (
+    name: 'Fake Streaming Gauges',
+    description: 'A live server dashboard — all computation happens in Python '
+        'with sleep-based pacing.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Live dashboard (Python-driven)',
+        narration: 'Creates a bar chart as gauge display, then streams '
+            '30 ticks of Ornstein-Uhlenbeck random data at ~400ms intervals. '
+            'Python computes the data and calls sleep() between ticks.',
+        code: '''
+seed = [42]
+labels = ["CPU", "MEM", "NET", "DSK", "TMP"]
+mus = [55.0, 40.0, 65.0, 25.0, 50.0]
+vals = [55.0, 40.0, 65.0, 25.0, 50.0]
+
+chart_id = chart_create({
+    "type": "bar", "title": "Server Dashboard (Live)",
+    "labels": labels, "values": vals
+})
+
+for tick in range(30):
+    for i in range(5):
+        seed[0] = (seed[0] * 1103515245 + 12345) % 2147483648
+        n = (seed[0] / 2147483648) * 2 - 1
+        vals[i] = vals[i] + 0.15 * (mus[i] - vals[i]) + 8 * n
+        if vals[i] < 0:
+            vals[i] = 0.0
+        if vals[i] > 100:
+            vals[i] = 100.0
+    r = []
+    for v in vals:
+        r.append(round(v * 10) / 10)
+    parts = []
+    for j in range(5):
+        parts.append(labels[j] + ":" + str(r[j]) + "%")
+    print("[" + str(tick + 1) + "] " + " ".join(parts))
+    chart_update(chart_id, {
+        "type": "bar", "title": "Server Dashboard (Live)",
+        "labels": labels, "values": r
+    })
+    sleep(400)
+print("Stream ended.")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 6: Stream Gauges ────────────────────────────────────
+
+  static const ShowcaseDemo _streamGauges = (
+    name: 'Stream Gauges',
+    description:
+        'A live server dashboard — Dart produces O-U data via a stream, '
+        'Python consumes it with stream_subscribe / stream_next.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Live dashboard (Dart-driven)',
+        narration: 'Subscribes to a Dart-side "server_metrics" stream that '
+            'emits 30 ticks at ~400ms. Python pulls each snapshot and '
+            'updates the chart — no sleep needed.',
+        code: '''
+chart_id = chart_create({
+    "type": "bar", "title": "Server Dashboard (Live)",
+    "labels": ["CPU", "MEM", "NET", "DSK", "TMP"],
+    "values": [50, 50, 50, 50, 50]
+})
+
+handle = stream_subscribe("server_metrics")
+tick = 0
+while True:
+    snapshot = stream_next(handle)
+    if snapshot is None:
+        break
+    tick = tick + 1
+    vals = snapshot["values"]
+    parts = []
+    for j in range(5):
+        parts.append(snapshot["labels"][j] + ":" + str(vals[j]) + "%")
+    print("[" + str(tick) + "] " + " ".join(parts))
+    chart_update(chart_id, snapshot)
+
+stream_close(handle)
+print("Stream ended.")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 7: Pie Chart ─────────────────────────────────────────
+
+  static const ShowcaseDemo _pieChart = (
+    name: 'Pie Chart',
+    description: 'Renders a pie chart showing browser market share.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Create pie chart',
+        narration: 'Visualize browser market share as a pie chart.',
+        code: '''
+browsers = ["Chrome", "Safari", "Firefox", "Edge", "Other"]
+share = [65.0, 18.5, 6.3, 5.2, 5.0]
+
+i = 0
+while i < len(browsers):
+    print(browsers[i] + ": " + str(share[i]) + "%")
+    i = i + 1
+
+chart_create({
+    "type": "pie",
+    "title": "Browser Market Share 2025",
+    "labels": browsers,
+    "values": share,
+    "center_radius": 40
+})
+print("Pie chart rendered!")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 6: Radar Chart ────────────────────────────────────────
+
+  static const ShowcaseDemo _radarChart = (
+    name: 'Radar Chart',
+    description: 'Displays a radar chart comparing team performance metrics.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Create radar chart',
+        narration: 'Plot team metrics across 5 axes on a radar chart.',
+        code: '''
+axes = ["Speed", "Quality", "Teamwork", "Innovation", "Delivery"]
+values = [85, 92, 78, 88, 95]
+
+i = 0
+while i < len(axes):
+    print(axes[i] + ": " + str(values[i]) + "/100")
+    i = i + 1
+
+chart_create({
+    "type": "radar",
+    "title": "Team Performance Metrics",
+    "axes": axes,
+    "values": values
+})
+print("Radar chart rendered!")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 7: Heatmap ────────────────────────────────────────────
+
+  static const ShowcaseDemo _heatmap = (
+    name: 'Heatmap',
+    description: 'Renders a correlation heatmap from computed data.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Compute correlation matrix',
+        narration: 'Build a correlation matrix and render as a heatmap.',
+        code: '''
+features = ["Price", "Size", "Rooms", "Age", "Distance"]
+# Symmetric correlation matrix (flattened row-major)
+corr = [
+    1.0, 0.85, 0.72, -0.45, -0.62,
+    0.85, 1.0, 0.91, -0.38, -0.55,
+    0.72, 0.91, 1.0, -0.28, -0.48,
+    -0.45, -0.38, -0.28, 1.0, 0.35,
+    -0.62, -0.55, -0.48, 0.35, 1.0,
+]
+
+print("Correlation Matrix:")
+for i in range(5):
+    row = corr[i*5:(i+1)*5]
+    parts = []
+    for v in row:
+        parts.append(str(round(v * 100) / 100))
+    vals = " ".join(parts)
+    print("  " + features[i] + ": " + vals)
+
+chart_create({
+    "type": "heatmap",
+    "title": "Feature Correlation Matrix",
+    "rows": 5,
+    "cols": 5,
+    "values": corr,
+    "row_labels": features,
+    "col_labels": features
+})
+print("Heatmap rendered!")
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 8: Drawing Recognition ────────────────────────────────
+
+  static const ShowcaseDemo _drawingRecognition = (
+    name: 'Drawing Recognition',
+    description: 'Draw on a canvas, submit, and the LLM identifies the letter.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Capture and recognize drawing',
+        narration: 'Subscribe to drawing input, compute fill density, '
+            'then ask the LLM.',
+        code: r'''
+def calculate_density(raw_data):
+    data_str = str(raw_data)
+    lines = data_str.strip().split("\n")
+    filled = 0
+    total = 0
+    for row in lines:
+        for ch in row:
+            total = total + 1
+            if ch == "#":
+                filled = filled + 1
+    pct = filled * 100 / total if total > 0 else 0
+    return pct
+
+def identify_letter(raw_data):
+    prompt = "Analyze this ASCII art drawing:\n\n" + str(raw_data)
+    result = str(ask_llm(prompt, "letter-drawing"))
+    print("LLM reasoning:")
+    print(result)
+    # Parse out the final answer
+    marker = "FINAL ANSWER:"
+    idx = result.find(marker)
+    if idx >= 0:
+        answer = result[idx + len(marker):].strip()
+        return answer[0] if len(answer) > 0 else "?"
+    return "?"
+
+def main():
+    handle = stream_subscribe("drawing_input")
+    print("Waiting for drawing submission...")
+    data = stream_next(handle)
+    if data is not None:
+        print("Received drawing:")
+        print(data)
+        pct = calculate_density(data)
+        print("Fill density: " + str(int(pct)) + "%")
+        print("Asking LLM to identify the letter...")
+        letter = identify_letter(data)
+        print("Identified letter: " + letter)
+    else:
+        print("No drawing received.")
+    stream_close(handle)
+    print("Done!")
+
+main()
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 9: Form Validation ────────────────────────────────────
+
+  static const ShowcaseDemo _formValidation = (
+    name: 'Form Validation',
+    description: 'Python creates a form, validates submissions, shows errors.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Create and validate form',
+        narration: 'Create a form with fields and validate user input.',
+        code: '''
+form_id = form_create([
+    {"name": "username", "label": "Username", "type": "text"},
+    {"name": "email", "label": "Email", "type": "text"},
+    {"name": "age", "label": "Age", "type": "number"}
+])
+print(f"Form created (id={form_id})")
+
+handle = stream_subscribe("form_submissions")
+print("Waiting for form submission...")
+data = stream_next(handle)
+if data is not None:
+    print(f"Received: {data}")
+    errors = {}
+    username = data["username"] if "username" in data else ""
+    email = data["email"] if "email" in data else ""
+    age = data["age"] if "age" in data else ""
+    if len(str(username)) < 3:
+        errors["username"] = "Must be at least 3 characters"
+    if "@" not in str(email):
+        errors["email"] = "Must contain @"
+    if errors:
+        form_set_errors(form_id, errors)
+        print(f"Validation errors: {errors}")
+    else:
+        print("All fields valid!")
+else:
+    print("No submission received.")
+stream_close(handle)
+''',
+      ),
+    ],
+  );
+
+  // ── Demo 12: Tic-Tac-Toe vs LLM ─────────────────────────────
+
+  static const ShowcaseDemo _ticTacToe = (
+    name: 'Tic-Tac-Toe',
+    description: 'Play tic-tac-toe against the LLM. You are X, LLM is O.',
+    steps: [
+      ShowcaseDemoStep(
+        title: 'Step 1: Play tic-tac-toe',
+        narration: 'Tap a cell to place X. The LLM picks its move as O. '
+            'Game loops until someone wins or a draw.',
+        code: r'''
+def format_board(board):
+    result = ""
+    i = 0
+    while i < 3:
+        row = ""
+        j = 0
+        while j < 3:
+            cell = board[i * 3 + j]
+            if cell == "":
+                row = row + str(i * 3 + j + 1)
+            else:
+                row = row + cell
+            if j < 2:
+                row = row + " | "
+            j = j + 1
+        result = result + row + "\n"
+        if i < 2:
+            result = result + "---------\n"
+        i = i + 1
+    return result
+
+def check_winner(board):
+    lines = [
+        [0,1,2], [3,4,5], [6,7,8],
+        [0,3,6], [1,4,7], [2,5,8],
+        [0,4,8], [2,4,6]
+    ]
+    for line in lines:
+        a = board[line[0]]
+        b = board[line[1]]
+        c = board[line[2]]
+        if a != "" and a == b and b == c:
+            return a
+    return ""
+
+def count_empty(board):
+    n = 0
+    for c in board:
+        if c == "":
+            n = n + 1
+    return n
+
+def get_llm_move(board, thread_id):
+    board_str = format_board(board)
+    prompt = "Current board:\n" + board_str + "\nPick an empty cell number."
+    resp = ask_llm(prompt, "tic-tac-toe", thread_id)
+    result = str(resp["text"])
+    new_tid = resp["thread_id"]
+    for ch in result:
+        if ch >= "1" and ch <= "9":
+            idx = int(ch) - 1
+            if board[idx] == "":
+                return (idx, new_tid)
+    # Fallback: first empty cell
+    i = 0
+    while i < 9:
+        if board[i] == "":
+            return (i, new_tid)
+        i = i + 1
+    return (-1, new_tid)
+
+def main():
+    board = ["", "", "", "", "", "", "", "", ""]
+    handle = stream_subscribe("ttt_input")
+    thread_id = None
+    print("Tic-Tac-Toe! You are X, LLM is O.")
+    print("Tap a cell to play.")
+    print(format_board(board))
+
+    while True:
+        data = stream_next(handle)
+        if data is None:
+            break
+        cell = int(str(data))
+        if cell < 0 or cell > 8 or board[cell] != "":
+            print("Cell occupied, try again.")
+            continue
+        board[cell] = "X"
+        ttt_move(cell, "X")
+        print("You played X at " + str(cell + 1))
+        print(format_board(board))
+
+        w = check_winner(board)
+        if w == "X":
+            print("You win!")
+            break
+        if count_empty(board) == 0:
+            print("Draw!")
+            break
+
+        print("LLM thinking...")
+        move, thread_id = get_llm_move(board, thread_id)
+        board[move] = "O"
+        ttt_move(move, "O")
+        print("LLM played O at " + str(move + 1))
+        print(format_board(board))
+
+        w = check_winner(board)
+        if w == "O":
+            print("LLM wins!")
+            break
+        if count_empty(board) == 0:
+            print("Draw!")
+            break
+
+    stream_close(handle)
+    print("Game over!")
+
+main()
+''',
+      ),
+    ],
+  );
+}

--- a/packages/soliplex_showcase/lib/src/demo_step.dart
+++ b/packages/soliplex_showcase/lib/src/demo_step.dart
@@ -1,0 +1,22 @@
+/// A single step in a showcase demo.
+class ShowcaseDemoStep {
+  /// Creates a demo step.
+  const ShowcaseDemoStep({
+    required this.title,
+    required this.narration,
+    required this.code,
+    this.expectsError = false,
+  });
+
+  /// Human-readable step title, e.g. "Step 1: Create DataFrame".
+  final String title;
+
+  /// Narrator text explaining what this step demonstrates.
+  final String narration;
+
+  /// Python source code to execute.
+  final String code;
+
+  /// If `true`, the step is expected to produce an error.
+  final bool expectsError;
+}

--- a/packages/soliplex_showcase/lib/src/drawing_grid.dart
+++ b/packages/soliplex_showcase/lib/src/drawing_grid.dart
@@ -1,0 +1,46 @@
+/// A simple 20×20 boolean grid for drawing input.
+class DrawingGrid {
+  /// Creates a blank 20×20 grid.
+  DrawingGrid() : _cells = List.generate(20, (_) => List.filled(20, false));
+
+  final List<List<bool>> _cells;
+
+  /// Grid size (always 20).
+  static const size = 20;
+
+  /// Mark the cell at ([row], [col]) as filled.
+  void setCell(int row, int col) {
+    if (row >= 0 && row < size && col >= 0 && col < size) {
+      _cells[row][col] = true;
+    }
+  }
+
+  /// Whether the cell at ([row], [col]) is filled.
+  bool getCell(int row, int col) {
+    if (row >= 0 && row < size && col >= 0 && col < size) {
+      return _cells[row][col];
+    }
+    return false;
+  }
+
+  /// Converts the grid to ASCII art: `#` for filled, `.` for empty.
+  String toAscii() {
+    final buf = StringBuffer();
+    for (var r = 0; r < size; r++) {
+      for (var c = 0; c < size; c++) {
+        buf.write(_cells[r][c] ? '#' : '.');
+      }
+      if (r < size - 1) buf.writeln();
+    }
+    return buf.toString();
+  }
+
+  /// Reset all cells to empty.
+  void clear() {
+    for (var r = 0; r < size; r++) {
+      for (var c = 0; c < size; c++) {
+        _cells[r][c] = false;
+      }
+    }
+  }
+}

--- a/packages/soliplex_showcase/lib/src/stream_factories.dart
+++ b/packages/soliplex_showcase/lib/src/stream_factories.dart
@@ -1,0 +1,87 @@
+import 'dart:math';
+
+/// Creates a stream yielding 30 radar config maps at ~400ms intervals.
+///
+/// Simulates an Ornstein-Uhlenbeck random walk on 5 axes, producing
+/// gradually changing radar chart data.
+Stream<Object?> radarMetricsStream() async* {
+  final rng = Random();
+  final axes = ['Speed', 'Quality', 'Teamwork', 'Innovation', 'Delivery'];
+  final values = [80.0, 85.0, 75.0, 90.0, 88.0];
+
+  for (var tick = 0; tick < 30; tick++) {
+    // O-U random walk: mean-revert towards 80, add noise.
+    for (var i = 0; i < values.length; i++) {
+      final noise = (rng.nextDouble() - 0.5) * 10;
+      values[i] = values[i] + 0.1 * (80 - values[i]) + noise;
+      values[i] = values[i].clamp(20, 100);
+    }
+
+    yield <String, Object?>{
+      'type': 'radar',
+      'title': 'Live Metrics (tick ${tick + 1}/30)',
+      'axes': List<String>.from(axes),
+      'values': List<double>.from(values),
+    };
+
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+  }
+}
+
+/// Creates a stream yielding 30 bar-chart config maps at ~400ms intervals.
+///
+/// Simulates a server dashboard with Ornstein-Uhlenbeck mean-reverting
+/// random walks on 5 metrics: CPU, MEM, NET, DSK, TMP.
+Stream<Object?> serverMetricsStream() async* {
+  final labels = ['CPU', 'MEM', 'NET', 'DSK', 'TMP'];
+  final mus = [55.0, 40.0, 65.0, 25.0, 50.0];
+  final vals = [...mus];
+  var seed = 42;
+
+  for (var tick = 0; tick < 30; tick++) {
+    await Future<void>.delayed(const Duration(milliseconds: 400));
+    for (var i = 0; i < 5; i++) {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      final n = (seed / 2147483648) * 2 - 1;
+      vals[i] = (vals[i] + 0.15 * (mus[i] - vals[i]) + 8 * n).clamp(0, 100);
+    }
+    yield <String, Object?>{
+      'type': 'bar',
+      'title': 'Server Dashboard (Live)',
+      'labels': List<String>.from(labels),
+      'values': vals.map((v) => (v * 10).round() / 10).toList(),
+    };
+  }
+}
+
+/// Creates a stream yielding 20 pie config maps at ~500ms intervals.
+///
+/// Simulates fluctuating browser market share data.
+Stream<Object?> marketShareStream() async* {
+  final rng = Random();
+  final browsers = ['Chrome', 'Safari', 'Firefox', 'Edge', 'Other'];
+  final shares = [65.0, 18.5, 6.3, 5.2, 5.0];
+
+  for (var tick = 0; tick < 20; tick++) {
+    // Randomly shift shares.
+    for (var i = 0; i < shares.length; i++) {
+      shares[i] += (rng.nextDouble() - 0.5) * 2;
+      if (shares[i] < 1) shares[i] = 1;
+    }
+    // Normalize to 100%.
+    final total = shares.reduce((a, b) => a + b);
+    for (var i = 0; i < shares.length; i++) {
+      shares[i] = (shares[i] / total * 100 * 10).roundToDouble() / 10;
+    }
+
+    yield <String, Object?>{
+      'type': 'pie',
+      'title': 'Market Share (tick ${tick + 1}/20)',
+      'labels': List<String>.from(browsers),
+      'values': List<double>.from(shares),
+      'center_radius': 40,
+    };
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+  }
+}

--- a/packages/soliplex_showcase/lib/src/tic_tac_toe_grid.dart
+++ b/packages/soliplex_showcase/lib/src/tic_tac_toe_grid.dart
@@ -1,0 +1,39 @@
+/// A 3×3 tic-tac-toe board that tracks game state.
+class TicTacToeGrid {
+  /// Grid dimension.
+  static const size = 3;
+
+  /// Board cells: each is `''` (empty), `'X'`, or `'O'`.
+  final List<String> _cells = List<String>.filled(9, '');
+
+  /// Returns the value at [index] (0-8).
+  String getCell(int index) => _cells[index];
+
+  /// Places [player] at [index]. Returns `false` if occupied or
+  /// out of range.
+  bool play(int index, String player) {
+    if (index < 0 || index > 8 || _cells[index] != '') return false;
+    _cells[index] = player;
+    return true;
+  }
+
+  /// Returns `'X'`, `'O'`, `'draw'`, or `''` (game in progress).
+  String checkWinner() {
+    const lines = [
+      [0, 1, 2], [3, 4, 5], [6, 7, 8], // rows
+      [0, 3, 6], [1, 4, 7], [2, 5, 8], // cols
+      [0, 4, 8], [2, 4, 6], // diags
+    ];
+    for (final line in lines) {
+      final a = _cells[line[0]];
+      if (a != '' && a == _cells[line[1]] && a == _cells[line[2]]) {
+        return a;
+      }
+    }
+    if (_cells.every((c) => c != '')) return 'draw';
+    return '';
+  }
+
+  /// Clears every cell.
+  void reset() => _cells.fillRange(0, 9, '');
+}

--- a/packages/soliplex_showcase/pubspec.yaml
+++ b/packages/soliplex_showcase/pubspec.yaml
@@ -1,0 +1,14 @@
+name: soliplex_showcase
+description: Showcase demo definitions for the Soliplex Monty interpreter.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+dependencies:
+  meta: ^1.11.0
+
+dev_dependencies:
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0

--- a/packages/soliplex_showcase/test/demo_registry_test.dart
+++ b/packages/soliplex_showcase/test/demo_registry_test.dart
@@ -1,0 +1,74 @@
+import 'package:soliplex_showcase/soliplex_showcase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ShowcaseDemoRegistry', () {
+    test('has exactly 12 demos', () {
+      expect(ShowcaseDemoRegistry.demos, hasLength(12));
+    });
+
+    test('all demos have non-empty steps', () {
+      for (final demo in ShowcaseDemoRegistry.demos) {
+        expect(
+          demo.steps,
+          isNotEmpty,
+          reason: '${demo.name} should have steps',
+        );
+      }
+    });
+
+    test('all steps have non-empty code', () {
+      for (final demo in ShowcaseDemoRegistry.demos) {
+        for (final step in demo.steps) {
+          expect(
+            step.code.trim(),
+            isNotEmpty,
+            reason: '${demo.name} > ${step.title} should have code',
+          );
+        }
+      }
+    });
+
+    test('all demos have non-empty name and description', () {
+      for (final demo in ShowcaseDemoRegistry.demos) {
+        expect(demo.name, isNotEmpty);
+        expect(demo.description, isNotEmpty);
+      }
+    });
+
+    test('all steps have non-empty title and narration', () {
+      for (final demo in ShowcaseDemoRegistry.demos) {
+        for (final step in demo.steps) {
+          expect(
+            step.title,
+            isNotEmpty,
+            reason: '${demo.name} step should have title',
+          );
+          expect(
+            step.narration,
+            isNotEmpty,
+            reason: '${demo.name} step should have narration',
+          );
+        }
+      }
+    });
+
+    test('demo names match expected list', () {
+      final names = ShowcaseDemoRegistry.demos.map((d) => d.name).toList();
+      expect(names, [
+        'Error Recovery',
+        'DataFrame → Chart',
+        'Scatter Plot',
+        'Multi-Step Analysis',
+        'Fake Streaming Gauges',
+        'Stream Gauges',
+        'Pie Chart',
+        'Radar Chart',
+        'Heatmap',
+        'Drawing Recognition',
+        'Form Validation',
+        'Tic-Tac-Toe',
+      ]);
+    });
+  });
+}

--- a/packages/soliplex_showcase/test/drawing_grid_test.dart
+++ b/packages/soliplex_showcase/test/drawing_grid_test.dart
@@ -1,0 +1,70 @@
+import 'package:soliplex_showcase/soliplex_showcase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DrawingGrid', () {
+    late DrawingGrid grid;
+
+    setUp(() {
+      grid = DrawingGrid();
+    });
+
+    test('starts empty', () {
+      for (var r = 0; r < DrawingGrid.size; r++) {
+        for (var c = 0; c < DrawingGrid.size; c++) {
+          expect(grid.getCell(r, c), isFalse);
+        }
+      }
+    });
+
+    test('setCell marks correct position', () {
+      grid.setCell(5, 10);
+      expect(grid.getCell(5, 10), isTrue);
+      expect(grid.getCell(5, 11), isFalse);
+      expect(grid.getCell(4, 10), isFalse);
+    });
+
+    test('setCell ignores out-of-bounds', () {
+      grid
+        ..setCell(-1, 0)
+        ..setCell(0, -1)
+        ..setCell(20, 0)
+        ..setCell(0, 20);
+      // Should not throw and grid stays empty.
+      expect(grid.getCell(0, 0), isFalse);
+    });
+
+    test('getCell returns false for out-of-bounds', () {
+      expect(grid.getCell(-1, 0), isFalse);
+      expect(grid.getCell(0, -1), isFalse);
+      expect(grid.getCell(20, 0), isFalse);
+      expect(grid.getCell(0, 20), isFalse);
+    });
+
+    test('toAscii produces expected output', () {
+      grid
+        ..setCell(0, 0)
+        ..setCell(0, 1)
+        ..setCell(1, 0);
+
+      final ascii = grid.toAscii();
+      final lines = ascii.split('\n');
+      expect(lines, hasLength(DrawingGrid.size));
+      expect(lines[0], startsWith('##'));
+      expect(lines[1], startsWith('#.'));
+      expect(lines[2], startsWith('..'));
+    });
+
+    test('clear resets grid', () {
+      grid
+        ..setCell(3, 3)
+        ..setCell(7, 7);
+      expect(grid.getCell(3, 3), isTrue);
+
+      grid.clear();
+
+      expect(grid.getCell(3, 3), isFalse);
+      expect(grid.getCell(7, 7), isFalse);
+    });
+  });
+}

--- a/packages/soliplex_showcase/test/stream_factories_test.dart
+++ b/packages/soliplex_showcase/test/stream_factories_test.dart
@@ -1,0 +1,64 @@
+import 'package:soliplex_showcase/soliplex_showcase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'radarMetricsStream',
+    () {
+      test('yields 30 items then ends', () async {
+        final items = await radarMetricsStream().toList();
+        expect(items, hasLength(30));
+      });
+
+      test('each item is a radar config map', () async {
+        final item = await radarMetricsStream().first;
+        expect(item, isA<Map<String, Object?>>());
+        final map = item! as Map<String, Object?>;
+        expect(map['type'], 'radar');
+        expect(map['axes'], isA<List<String>>());
+        expect(map['values'], isA<List<double>>());
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+
+  group(
+    'marketShareStream',
+    () {
+      test('yields 20 items then ends', () async {
+        final items = await marketShareStream().toList();
+        expect(items, hasLength(20));
+      });
+
+      test('each item is a pie config map', () async {
+        final item = await marketShareStream().first;
+        expect(item, isA<Map<String, Object?>>());
+        final map = item! as Map<String, Object?>;
+        expect(map['type'], 'pie');
+        expect(map['labels'], isA<List<String>>());
+        expect(map['values'], isA<List<double>>());
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+
+  group(
+    'serverMetricsStream',
+    () {
+      test('yields 30 items then ends', () async {
+        final items = await serverMetricsStream().toList();
+        expect(items, hasLength(30));
+      });
+
+      test('each item is a bar config map', () async {
+        final item = await serverMetricsStream().first;
+        expect(item, isA<Map<String, Object?>>());
+        final map = item! as Map<String, Object?>;
+        expect(map['type'], 'bar');
+        expect(map['labels'], isA<List<String>>());
+        expect(map['values'], isA<List<Object?>>());
+      });
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+}

--- a/packages/soliplex_showcase/test/tic_tac_toe_grid_test.dart
+++ b/packages/soliplex_showcase/test/tic_tac_toe_grid_test.dart
@@ -1,0 +1,93 @@
+import 'package:soliplex_showcase/soliplex_showcase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TicTacToeGrid', () {
+    late TicTacToeGrid grid;
+
+    setUp(() => grid = TicTacToeGrid());
+
+    test('starts empty with no winner', () {
+      for (var i = 0; i < 9; i++) {
+        expect(grid.getCell(i), '');
+      }
+      expect(grid.checkWinner(), '');
+    });
+
+    test('play marks cell correctly', () {
+      expect(grid.play(4, 'X'), isTrue);
+      expect(grid.getCell(4), 'X');
+    });
+
+    test('play on occupied cell returns false', () {
+      grid.play(0, 'X');
+      expect(grid.play(0, 'O'), isFalse);
+      expect(grid.getCell(0), 'X');
+    });
+
+    test('play out of range returns false', () {
+      expect(grid.play(-1, 'X'), isFalse);
+      expect(grid.play(9, 'X'), isFalse);
+    });
+
+    test('detects horizontal win', () {
+      grid
+        ..play(0, 'X')
+        ..play(1, 'X')
+        ..play(2, 'X');
+      expect(grid.checkWinner(), 'X');
+    });
+
+    test('detects vertical win', () {
+      grid
+        ..play(1, 'O')
+        ..play(4, 'O')
+        ..play(7, 'O');
+      expect(grid.checkWinner(), 'O');
+    });
+
+    test('detects diagonal win', () {
+      grid
+        ..play(0, 'X')
+        ..play(4, 'X')
+        ..play(8, 'X');
+      expect(grid.checkWinner(), 'X');
+    });
+
+    test('detects anti-diagonal win', () {
+      grid
+        ..play(2, 'O')
+        ..play(4, 'O')
+        ..play(6, 'O');
+      expect(grid.checkWinner(), 'O');
+    });
+
+    test('detects draw when board full with no winner', () {
+      // X O X
+      // X X O
+      // O X O
+      grid
+        ..play(0, 'X')
+        ..play(1, 'O')
+        ..play(2, 'X')
+        ..play(3, 'X')
+        ..play(4, 'X')
+        ..play(5, 'O')
+        ..play(6, 'O')
+        ..play(7, 'X')
+        ..play(8, 'O');
+      expect(grid.checkWinner(), 'draw');
+    });
+
+    test('reset clears board', () {
+      grid
+        ..play(0, 'X')
+        ..play(4, 'O')
+        ..reset();
+      for (var i = 0; i < 9; i++) {
+        expect(grid.getCell(i), '');
+      }
+      expect(grid.checkWinner(), '');
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -981,6 +981,13 @@ packages:
       relative: true
     source: path
     version: "0.1.0"
+  soliplex_showcase:
+    dependency: "direct main"
+    description:
+      path: "packages/soliplex_showcase"
+      relative: true
+    source: path
+    version: "0.1.0"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
     path: packages/soliplex_monty
   soliplex_scripting:
     path: packages/soliplex_scripting
+  soliplex_showcase:
+    path: packages/soliplex_showcase
   url_launcher: ^6.3.2
   uuid: ^4.5.1
   wakelock_plus:

--- a/test/features/debug/debug_chart_config_test.dart
+++ b/test/features/debug/debug_chart_config_test.dart
@@ -84,6 +84,133 @@ void main() {
       });
     });
 
+    group('pie chart', () {
+      test('parses valid config', () {
+        final config = DebugChartConfig.fromMap({
+          'type': 'pie',
+          'title': 'Market Share',
+          'labels': ['Chrome', 'Safari', 'Firefox'],
+          'values': [65.0, 18.5, 6.3],
+          'center_radius': 50,
+        });
+
+        expect(config, isA<PieChartConfig>());
+        final pie = config as PieChartConfig;
+        expect(pie.title, 'Market Share');
+        expect(pie.labels, ['Chrome', 'Safari', 'Firefox']);
+        expect(pie.values, [65.0, 18.5, 6.3]);
+        expect(pie.centerRadius, 50.0);
+      });
+
+      test('uses defaults for missing optional fields', () {
+        final config = DebugChartConfig.fromMap({'type': 'pie'});
+
+        final pie = config as PieChartConfig;
+        expect(pie.labels, isEmpty);
+        expect(pie.values, isEmpty);
+        expect(pie.centerRadius, 40.0);
+      });
+    });
+
+    group('radar chart', () {
+      test('parses valid config', () {
+        final config = DebugChartConfig.fromMap({
+          'type': 'radar',
+          'title': 'Performance',
+          'axes': ['Speed', 'Quality', 'Cost'],
+          'values': [80, 90, 70],
+        });
+
+        expect(config, isA<RadarChartConfig>());
+        final radar = config as RadarChartConfig;
+        expect(radar.title, 'Performance');
+        expect(radar.axes, ['Speed', 'Quality', 'Cost']);
+        expect(radar.values, [80.0, 90.0, 70.0]);
+      });
+    });
+
+    group('image config', () {
+      test('parses valid config', () {
+        final config = DebugChartConfig.fromMap({
+          'type': 'image',
+          'title': 'Test Image',
+          'width': 2,
+          'height': 2,
+          'pixels': [
+            255,
+            0,
+            0,
+            255,
+            0,
+            255,
+            0,
+            255,
+            0,
+            0,
+            255,
+            255,
+            255,
+            255,
+            255,
+            255,
+          ],
+        });
+
+        expect(config, isA<ImageConfig>());
+        final img = config as ImageConfig;
+        expect(img.width, 2);
+        expect(img.height, 2);
+        expect(img.pixels, hasLength(16));
+      });
+    });
+
+    group('graph config', () {
+      test('parses valid config', () {
+        final config = DebugChartConfig.fromMap({
+          'type': 'graph',
+          'title': 'Network',
+          'nodes': ['A', 'B', 'C'],
+          'edges': [
+            [0, 1],
+            [1, 2],
+          ],
+          'positions': [
+            [0, 0],
+            [1, 0],
+            [0.5, 1],
+          ],
+        });
+
+        expect(config, isA<GraphConfig>());
+        final graph = config as GraphConfig;
+        expect(graph.nodes, ['A', 'B', 'C']);
+        expect(graph.edges, [(0, 1), (1, 2)]);
+        expect(graph.positions, hasLength(3));
+      });
+    });
+
+    group('heatmap config', () {
+      test('parses valid config', () {
+        final config = DebugChartConfig.fromMap({
+          'type': 'heatmap',
+          'title': 'Correlation',
+          'rows': 2,
+          'cols': 2,
+          'values': [1.0, 0.5, 0.5, 1.0],
+          'row_labels': ['A', 'B'],
+          'col_labels': ['A', 'B'],
+        });
+
+        expect(config, isA<HeatmapConfig>());
+        final hm = config as HeatmapConfig;
+        expect(hm.rows, 2);
+        expect(hm.cols, 2);
+        expect(hm.values, [1.0, 0.5, 0.5, 1.0]);
+        expect(hm.rowLabels, ['A', 'B']);
+        expect(hm.colLabels, ['A', 'B']);
+      });
+    });
+
     group('error cases', () {
       test('throws FormatException when type is missing', () {
         expect(
@@ -101,7 +228,7 @@ void main() {
 
       test('throws FormatException for unknown chart type', () {
         expect(
-          () => DebugChartConfig.fromMap({'type': 'pie'}),
+          () => DebugChartConfig.fromMap({'type': 'unknown_type'}),
           throwsA(
             isA<FormatException>().having(
               (e) => e.message,


### PR DESCRIPTION
## Summary
- Add `soliplex_showcase` package with 12 demo definitions, drawing grid, tic-tac-toe grid, and stream factories
- Add 5 new chart types (pie, radar, heatmap, image, graph) to debug chart renderer
- Add `StreamRegistry` for Dart-to-Python stream consumption
- Add `FormApi` for dynamic form creation from Python
- Add `ask_llm` thread_id support for multi-turn LLM conversations
- Add `extraFunctions` parameter to `HostFunctionWiring` for custom host functions
- Wire `AgentRuntime` into showcase screen for LLM integration

## Changes
- **soliplex_showcase** (NEW): Demo registry with 12 demos, `DrawingGrid`, `TicTacToeGrid`, stream factories (`radarMetrics`, `marketShare`, `serverMetrics`)
- **soliplex_scripting**: `StreamRegistry`, `chart_update`/`sleep` host functions, `ask_llm` with `thread_id` param, `extraFunctions` on `HostFunctionWiring`
- **soliplex_agent**: `AgentApi.spawnAgent` gains `threadId` param, `getThreadId()` method, `FormApi` interface
- **soliplex_interpreter_monty**: `HostParamType.map` support, bridge host function improvements
- **debug_chart_config/renderer**: Pie, radar, heatmap, image, graph chart types
- **monty_showcase_screen**: Full overhaul — 12 demos, drawing canvas, form widget, tic-tac-toe grid, stream wiring, LLM integration

## Demos
1. Error Recovery — retry loop with typo fix
2. DataFrame → Chart — create data, render bar chart
3. Scatter Plot — √x curve
4. Multi-Step Analysis — filter, sort, growth chart
5. Fake Streaming Gauges — Python-driven O-U random walk with `chart_update` + `sleep`
6. Stream Gauges — Dart-driven O-U stream consumed by Python
7. Pie Chart — browser market share
8. Radar Chart — team performance metrics
9. Heatmap — correlation matrix
10. Drawing Recognition — canvas + `ask_llm` to identify letters
11. Form Validation — dynamic form with Python validation
12. Tic-Tac-Toe vs LLM — interactive game with multi-turn `ask_llm`

## Test plan
- [x] `dart test` passes in soliplex_showcase (28 tests)
- [x] `dart test` passes in soliplex_scripting (92 tests)
- [x] `flutter analyze --fatal-infos` clean on all changed packages
- [x] Manual: tic-tac-toe places X on tap, LLM responds with O on grid
- [ ] Manual: run all 12 demos end-to-end on macOS