### PR TITLE
fix(deps): add soliplex_schema to root pubspec

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -974,6 +974,13 @@ packages:
       relative: true
     source: path
     version: "0.1.0"
+  soliplex_schema:
+    dependency: "direct main"
+    description:
+      path: "packages/soliplex_schema"
+      relative: true
+    source: path
+    version: "0.1.0"
   soliplex_scripting:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
     path: packages/soliplex_logging
   soliplex_monty:
     path: packages/soliplex_monty
+  soliplex_schema:
+    path: packages/soliplex_schema
   soliplex_scripting:
     path: packages/soliplex_scripting
   url_launcher: ^6.3.2


### PR DESCRIPTION
## Summary
- Adds `soliplex_schema` as a path dependency in root `pubspec.yaml`
- Package exists in `packages/soliplex_schema/` but was missing from workspace dependency graph

## Changes
- **pubspec.yaml**: Added `soliplex_schema: path: packages/soliplex_schema`
- **pubspec.lock**: Updated with resolved dependency

## Test plan
- [x] `dart analyze --fatal-infos packages/soliplex_schema` — no issues
- [x] `dart test packages/soliplex_schema` — 59 tests pass
- [x] `dart format --set-exit-if-changed` — clean
- [x] All pre-commit hooks pass