### PR TITLE
docs(packages): add detailed descriptions and candidate packages

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -23,20 +23,94 @@ soliplex_monty             → interpreter_monty (via dart_monty)  (Flutter)
 
 ## Package Overview
 
-| Package | Type | Description |
-|---------|------|-------------|
-| [soliplex_logging](soliplex_logging/) | Pure Dart | Centralized logging, DiskQueue, BackendLogSink |
-| [soliplex_schema](soliplex_schema/) | Pure Dart | Runtime JSON Schema parsing for AG-UI features |
-| [soliplex_dataframe](soliplex_dataframe/) | Pure Dart | Pandas-like DataFrame engine with handle-based registry |
-| [soliplex_skills](soliplex_skills/) | Pure Dart | Skill loading and execution (.md and .py files) |
-| [soliplex_interpreter_monty](soliplex_interpreter_monty/) | Pure Dart | Monty Python sandbox bridge |
-| [soliplex_client](soliplex_client/) | Pure Dart | REST API client, AG-UI protocol, domain models |
-| [soliplex_client_native](soliplex_client_native/) | Flutter | Native HTTP platform adapters (Cupertino) |
-| [soliplex_agent](soliplex_agent/) | Pure Dart | Agent orchestration (RunOrchestrator, AgentRuntime) |
-| [soliplex_scripting](soliplex_scripting/) | Pure Dart | Wires AG-UI events to the Monty interpreter bridge |
-| [soliplex_cli](soliplex_cli/) | Pure Dart | Interactive REPL for exercising soliplex_agent |
-| [soliplex_tui](soliplex_tui/) | Pure Dart | Rich terminal UI for the agent backend |
-| [soliplex_monty](soliplex_monty/) | Flutter | Monty Python bridge with Flutter widgets |
+### [soliplex_client](soliplex_client/) — Pure Dart
+
+Core communications layer: REST API client, AG-UI streaming protocol, and all
+domain models (rooms, threads, runs, messages, tool calls). Everything that
+talks to the Soliplex backend flows through this package.
+
+### [soliplex_agent](soliplex_agent/) — Pure Dart
+
+Higher-level session abstraction where the scripting engine is wired in. This
+package is platform-aware — on WASM, `FutureSnapshot` is unavailable so Monty
+runs without `await`; on native, full async Python is supported. The intent is
+that the app layer becomes mostly widgets and wiring, with `soliplex_agent`
+owning the orchestration logic (`RunOrchestrator`, `AgentRuntime`,
+`AgentSession`).
+
+### [soliplex_scripting](soliplex_scripting/) — Pure Dart
+
+Generic scripting interface that bridges AG-UI events to an interpreter. Hard-
+wired to Monty today but the interface was validated against d4rt as well.
+
+### [soliplex_interpreter_monty](soliplex_interpreter_monty/) — Pure Dart
+
+Concrete Monty Python interpreter implementation. Provides the bridge between
+Dart and the Monty sandbox runtime.
+
+### [soliplex_client_native](soliplex_client_native/) — Flutter
+
+Native HTTP platform adapters (Cupertino networking). All platform-specific
+code lives here so the rest of the stack stays pure Dart.
+
+### [soliplex_logging](soliplex_logging/) — Pure Dart
+
+Advanced logging and telemetry. Supports structured log sinks, DiskQueue for
+offline buffering, and BackendLogSink for shipping logs to the server.
+
+### [soliplex_schema](soliplex_schema/) — Pure Dart
+
+Bridge for Soliplex feature schemas — Pydantic models on the server side that
+arrive as JSON Schema. Provides `SchemaStateView`, `FeatureSchemaRegistry`, and
+`SchemaParser` for typed access to feature state.
+
+### [soliplex_dataframe](soliplex_dataframe/) — Pure Dart
+
+Pandas-like DataFrame engine with a handle-based registry. Currently used for
+showcase demos, but DataFrames may ship as a first-class system feature if the
+API stabilizes.
+
+### [soliplex_skills](soliplex_skills/) — Pure Dart
+
+Client-side emulation of server skill data (prompts + Monty-centric Python
+resources). May be removable now that the server has landed native skills
+support.
+
+### [soliplex_cli](soliplex_cli/) — Pure Dart
+
+One-shot CLI for driving integration tests against `soliplex_agent`. Originally
+designed for agents to exercise the system in non-interactive mode.
+
+### [soliplex_tui](soliplex_tui/) — Pure Dart
+
+Interactive terminal UI for the agent backend. Does not support auth. Has proven
+valuable for agents running integration tests against live servers.
+
+### [soliplex_monty](soliplex_monty/) — Flutter (legacy)
+
+Legacy Flutter widget layer for the Monty bridge. Scheduled for removal — see
+[issue #46](https://github.com/runyaga/flutter/issues/46).
+
+## Candidate Packages
+
+### soliplex_lints (planned)
+
+Shared lint and analysis configuration for the monorepo. Would centralize
+`very_good_analysis` settings, formatter config, and analyzer excludes into one
+package that all targets include.
+
+Beyond standard lints, the scripting stack passes event streams through multiple
+layers (AG-UI events through `soliplex_scripting` into `soliplex_agent` and up
+to the app), creating many lifecycle resources (676 dispose/close/cancel calls
+across 102 files) that can easily leak if not cleaned up properly. Custom lint
+rules could enforce lifecycle cleanup at each layer boundary.
+
+DCM (`avoid-banned-imports`, `dispose-fields`, `close_sinks`,
+`cancel_subscriptions`) covers the initial enforcement cases. If DCM proves
+insufficient for our multi-layer streaming patterns, `soliplex_lints` would be
+the place to invest in `custom_lint` rules with full AST access. See
+[lint standardization plan](https://github.com/runyaga/flutter/issues/46) and
+the exploration at `/soliplex-plans/soliplex-lints-exploration.md`.
 
 ## Working on a Package
 

--- a/packages/soliplex_interpreter_monty/example/example.dart
+++ b/packages/soliplex_interpreter_monty/example/example.dart
@@ -4,11 +4,7 @@
 /// implementation backed by the Monty WASM runtime.
 library;
 
-// ignore_for_file: unused_local_variable
-
-import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
-
-Future<void> main() async {
+void main() {
   // 1. Create a bridge (requires a MontyPlatform implementation).
   // final bridge = DefaultMontyBridge(platform: myMontyPlatform);
 


### PR DESCRIPTION
## Summary
- Expand packages/README.md with 1-2 sentence descriptions per package
- Add Candidate Packages section for planned `soliplex_lints` package
- Fix interpreter_monty example analysis issues (unused import, stale ignore)

## Changes
- **packages/README.md**: Replace table with per-package sections covering purpose, platform constraints, and status. Mark `soliplex_monty` as legacy. Note `soliplex_skills` may be removable. Add `soliplex_lints` candidate section covering lifecycle/DCM rationale.
- **interpreter_monty/example/example.dart**: Remove unused import and stale `ignore_for_file` directive.

## Test plan
- [x] All pre-commit hooks pass
- [x] `dart analyze --fatal-infos` clean across all packages