### PR TITLE
fix(tooling): auto-resolve deps before package analysis

### DIFF
--- a/tool/analyze_packages.py
+++ b/tool/analyze_packages.py
@@ -46,6 +46,15 @@ def main() -> int:
             skipped.append(name)
             continue
         print(f"Analyzing {name}...")
+        # Ensure dependencies are resolved (needed in worktrees / fresh clones).
+        pkg_config = os.path.join(pkg_path, ".dart_tool", "package_config.json")
+        if not os.path.isfile(pkg_config):
+            subprocess.run(
+                ["dart", "pub", "get"],
+                cwd=pkg_path,
+                env=env,
+                capture_output=True,
+            )
         result = subprocess.run(
             ["dart", "analyze", "--fatal-infos", pkg_path],
             env=env,


### PR DESCRIPTION
## Summary
- Fix `dart-analyze-packages` pre-commit hook failing in worktrees and fresh clones

## Changes
- **tool/analyze_packages.py**: Run `dart pub get` when `.dart_tool/package_config.json` is missing before analyzing each package

## Test plan
- [x] Deleted `.dart_tool/` from `soliplex_cli` and `soliplex_skills`, ran script — both resolve and pass
- [x] All 13 packages pass analysis with the fix