### PR TITLE
refactor(http): HttpTransport sharing + doc updates

### DIFF
--- a/packages/soliplex_agent/lib/src/runtime/server_connection.dart
+++ b/packages/soliplex_agent/lib/src/runtime/server_connection.dart
@@ -36,15 +36,14 @@ class ServerConnection {
       'Got: $serverUrl',
     );
     final baseUrl = '$serverUrl/api/v1';
+    final transport = HttpTransport(client: httpClient);
+    final urlBuilder = UrlBuilder(baseUrl);
     return ServerConnection(
       serverId: serverId,
-      api: SoliplexApi(
-        transport: HttpTransport(client: httpClient),
-        urlBuilder: UrlBuilder(baseUrl),
-      ),
+      api: SoliplexApi(transport: transport, urlBuilder: urlBuilder),
       agUiStreamClient: AgUiStreamClient(
-        httpClient: httpClient,
-        urlBuilder: UrlBuilder(baseUrl),
+        httpTransport: transport,
+        urlBuilder: urlBuilder,
       ),
       onClose: onClose,
     );
@@ -62,9 +61,9 @@ class ServerConnection {
 
   final Future<void> Function()? _onClose;
 
-  /// Closes the API and AG-UI clients, then invokes any injected teardown.
+  /// Closes the API client (and its shared transport), then invokes any
+  /// injected teardown.
   Future<void> close() async {
-    agUiStreamClient.close();
     api.close();
     await _onClose?.call();
   }

--- a/packages/soliplex_agent/test/integration/helpers/integration_harness.dart
+++ b/packages/soliplex_agent/test/integration/helpers/integration_harness.dart
@@ -46,7 +46,7 @@ class IntegrationHarness {
     );
 
     agUiStreamClient = AgUiStreamClient(
-      httpClient: sseClient,
+      httpTransport: HttpTransport(client: sseClient),
       urlBuilder: UrlBuilder('$baseUrl/api/v1'),
     );
   }

--- a/packages/soliplex_cli/lib/src/client_factory.dart
+++ b/packages/soliplex_cli/lib/src/client_factory.dart
@@ -21,19 +21,17 @@ ServerConnection createVerboseConnection(String serverUrl) {
     observers: [observer],
   );
 
-  final transport = HttpTransport(client: apiHttpClient);
   final urlBuilder = UrlBuilder(baseUrl);
-
-  final api = SoliplexApi(transport: transport, urlBuilder: urlBuilder);
-  final agUiStreamClient = AgUiStreamClient(
-    httpClient: sseHttpClient,
-    urlBuilder: urlBuilder,
-  );
+  final apiTransport = HttpTransport(client: apiHttpClient);
+  final sseTransport = HttpTransport(client: sseHttpClient);
 
   return ServerConnection(
     serverId: 'default',
-    api: api,
-    agUiStreamClient: agUiStreamClient,
+    api: SoliplexApi(transport: apiTransport, urlBuilder: urlBuilder),
+    agUiStreamClient: AgUiStreamClient(
+      httpTransport: sseTransport,
+      urlBuilder: urlBuilder,
+    ),
     onClose: () async {
       apiHttpClient.close();
       sseHttpClient.close();

--- a/packages/soliplex_client/lib/src/http/agui_stream_client.dart
+++ b/packages/soliplex_client/lib/src/http/agui_stream_client.dart
@@ -1,30 +1,27 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
 // ignore: implementation_imports
 import 'package:ag_ui/src/sse/sse_parser.dart';
-import 'package:soliplex_client/src/errors/exceptions.dart';
-import 'package:soliplex_client/src/http/http_response.dart';
-import 'package:soliplex_client/src/http/soliplex_http_client.dart';
+import 'package:soliplex_client/src/http/http_transport.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 
 /// Streams AG-UI events using the Soliplex HTTP stack directly.
 ///
 /// Replaces [AgUiClient] usage in pure Dart packages. Routes SSE through
-/// [SoliplexHttpClient] so auth, observability, and platform clients
-/// apply automatically. No retry, no reconnection, no duplicate
-/// CancelToken.
+/// [HttpTransport] so status code mapping, auth, observability, cancel
+/// wrapping, and platform clients apply automatically. No retry, no
+/// reconnection, no duplicate CancelToken.
 class AgUiStreamClient {
-  /// Creates a client that streams AG-UI events via [httpClient].
+  /// Creates a client that streams AG-UI events via [httpTransport].
   AgUiStreamClient({
-    required SoliplexHttpClient httpClient,
+    required HttpTransport httpTransport,
     required UrlBuilder urlBuilder,
-  })  : _httpClient = httpClient,
+  })  : _httpTransport = httpTransport,
         _urlBuilder = urlBuilder;
 
-  final SoliplexHttpClient _httpClient;
+  final HttpTransport _httpTransport;
   final UrlBuilder _urlBuilder;
 
   /// Streams AG-UI events for a run.
@@ -37,7 +34,7 @@ class AgUiStreamClient {
     SimpleRunAgentInput input, {
     CancelToken? cancelToken,
   }) async* {
-    final response = await _httpClient.requestStream(
+    final response = await _httpTransport.requestStream(
       'POST',
       _urlBuilder.build(path: endpoint),
       headers: {
@@ -47,8 +44,6 @@ class AgUiStreamClient {
       body: input.toJson(),
       cancelToken: cancelToken,
     );
-
-    _checkStatusCode(response);
 
     final sseMessages = SseParser().parseBytes(response.body);
     const decoder = EventDecoder();
@@ -68,23 +63,6 @@ class AgUiStreamClient {
     }
   }
 
-  /// Checks the HTTP status code and throws on non-2xx responses.
-  ///
-  /// Drains the response body to release the TCP socket before throwing.
-  void _checkStatusCode(StreamedHttpResponse response) {
-    if (response.statusCode >= 200 && response.statusCode < 300) return;
-
-    // Drain the stream to release the underlying TCP socket.
-    unawaited(response.body.listen((_) {}).cancel());
-
-    final reason = response.reasonPhrase;
-    throw ApiException(
-      message: 'SSE connection failed: HTTP ${response.statusCode}'
-          '${reason != null ? ' ($reason)' : ''}',
-      statusCode: response.statusCode,
-    );
-  }
-
-  /// Closes the underlying HTTP client.
-  void close() => _httpClient.close();
+  /// Closes the underlying transport.
+  void close() => _httpTransport.close();
 }

--- a/packages/soliplex_client/test/http/agui_stream_client_test.dart
+++ b/packages/soliplex_client/test/http/agui_stream_client_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:ag_ui/ag_ui.dart' hide CancelToken;
@@ -6,12 +5,12 @@ import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_client/src/errors/exceptions.dart';
 import 'package:soliplex_client/src/http/agui_stream_client.dart';
 import 'package:soliplex_client/src/http/http_response.dart';
-import 'package:soliplex_client/src/http/soliplex_http_client.dart';
+import 'package:soliplex_client/src/http/http_transport.dart';
 import 'package:soliplex_client/src/utils/cancel_token.dart';
 import 'package:soliplex_client/src/utils/url_builder.dart';
 import 'package:test/test.dart';
 
-class MockSoliplexHttpClient extends Mock implements SoliplexHttpClient {}
+class MockHttpTransport extends Mock implements HttpTransport {}
 
 /// Encodes a list of SSE events into a byte stream.
 ///
@@ -27,7 +26,7 @@ Stream<List<int>> sseByteStream(List<Map<String, dynamic>> events) {
 }
 
 void main() {
-  late MockSoliplexHttpClient mockClient;
+  late MockHttpTransport mockTransport;
   late AgUiStreamClient client;
 
   const baseUrl = 'https://api.test/v1';
@@ -38,17 +37,17 @@ void main() {
   });
 
   setUp(() {
-    mockClient = MockSoliplexHttpClient();
+    mockTransport = MockHttpTransport();
     client = AgUiStreamClient(
-      httpClient: mockClient,
+      httpTransport: mockTransport,
       urlBuilder: UrlBuilder(baseUrl),
     );
-    when(() => mockClient.close()).thenReturn(null);
+    when(() => mockTransport.close()).thenReturn(null);
   });
 
   tearDown(() {
     client.close();
-    reset(mockClient);
+    reset(mockTransport);
   });
 
   group('AgUiStreamClient', () {
@@ -60,7 +59,7 @@ void main() {
         final token = CancelToken();
 
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -77,7 +76,7 @@ void main() {
         await client.runAgent(endpoint, input, cancelToken: token).toList();
 
         final captured = verify(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -91,7 +90,7 @@ void main() {
 
       test('builds correct URI from endpoint', () async {
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -108,7 +107,7 @@ void main() {
         await client.runAgent(endpoint, input).toList();
 
         final captured = verify(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             'POST',
             captureAny(),
             headers: any(named: 'headers'),
@@ -126,7 +125,7 @@ void main() {
 
       test('sends correct headers', () async {
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -143,7 +142,7 @@ void main() {
         await client.runAgent(endpoint, input).toList();
 
         final captured = verify(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: captureAny(named: 'headers'),
@@ -186,7 +185,7 @@ void main() {
         ];
 
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -234,7 +233,7 @@ void main() {
           ..writeln();
 
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -268,7 +267,7 @@ void main() {
           ..writeln();
 
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
@@ -290,127 +289,72 @@ void main() {
     });
 
     group('error handling', () {
-      test('throws ApiException on non-2xx status code', () async {
+      test('propagates AuthException from transport on 401', () async {
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
             body: any(named: 'body'),
             cancelToken: any(named: 'cancelToken'),
           ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
+        ).thenThrow(
+          const AuthException(message: 'Unauthorized', statusCode: 401),
+        );
+
+        expect(
+          () => client.runAgent(endpoint, input).toList(),
+          throwsA(isA<AuthException>()),
+        );
+      });
+
+      test('propagates ApiException from transport on 500', () async {
+        when(
+          () => mockTransport.requestStream(
+            any(),
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+            cancelToken: any(named: 'cancelToken'),
+          ),
+        ).thenThrow(
+          const ApiException(
+            message: 'Internal Server Error',
             statusCode: 500,
-            body: Stream.value(
-              utf8.encode('Internal Server Error'),
-            ),
-            reasonPhrase: 'Internal Server Error',
           ),
         );
 
         expect(
           () => client.runAgent(endpoint, input).toList(),
           throwsA(
-            isA<ApiException>()
-                .having((e) => e.statusCode, 'statusCode', 500)
-                .having(
-                  (e) => e.message,
-                  'message',
-                  contains('Internal Server Error'),
-                ),
+            isA<ApiException>().having((e) => e.statusCode, 'statusCode', 500),
           ),
         );
       });
 
-      test('throws ApiException on 401 status code', () async {
+      test('propagates CancelledException from transport', () async {
         when(
-          () => mockClient.requestStream(
+          () => mockTransport.requestStream(
             any(),
             any(),
             headers: any(named: 'headers'),
             body: any(named: 'body'),
             cancelToken: any(named: 'cancelToken'),
           ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
-            statusCode: 401,
-            body: Stream.value(utf8.encode('Unauthorized')),
-            reasonPhrase: 'Unauthorized',
-          ),
-        );
+        ).thenThrow(const CancelledException());
 
         expect(
           () => client.runAgent(endpoint, input).toList(),
-          throwsA(
-            isA<ApiException>().having((e) => e.statusCode, 'statusCode', 401),
-          ),
-        );
-      });
-
-      test('includes reason phrase in error when present', () async {
-        when(
-          () => mockClient.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
-            statusCode: 503,
-            body: Stream.value(utf8.encode('')),
-            reasonPhrase: 'Service Unavailable',
-          ),
-        );
-
-        expect(
-          () => client.runAgent(endpoint, input).toList(),
-          throwsA(
-            isA<ApiException>().having(
-              (e) => e.message,
-              'message',
-              'SSE connection failed: HTTP 503 (Service Unavailable)',
-            ),
-          ),
-        );
-      });
-
-      test('omits reason phrase from error when null', () async {
-        when(
-          () => mockClient.requestStream(
-            any(),
-            any(),
-            headers: any(named: 'headers'),
-            body: any(named: 'body'),
-            cancelToken: any(named: 'cancelToken'),
-          ),
-        ).thenAnswer(
-          (_) async => StreamedHttpResponse(
-            statusCode: 502,
-            body: Stream.value(utf8.encode('')),
-          ),
-        );
-
-        expect(
-          () => client.runAgent(endpoint, input).toList(),
-          throwsA(
-            isA<ApiException>().having(
-              (e) => e.message,
-              'message',
-              'SSE connection failed: HTTP 502',
-            ),
-          ),
+          throwsA(isA<CancelledException>()),
         );
       });
     });
 
     group('close', () {
-      test('delegates to httpClient.close()', () {
+      test('delegates to httpTransport.close()', () {
         client.close();
 
-        verify(() => mockClient.close()).called(1);
+        verify(() => mockTransport.close()).called(1);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Route AgUiStreamClient through HttpTransport instead of raw SoliplexHttpClient
- Update architecture docs for HTTP protocol consolidation
- Share single HttpTransport instance in ServerConnection.create()

## Changes
- **AgUiStreamClient**: `SoliplexHttpClient` → `HttpTransport`, delete `_checkStatusCode()` (~-20 LOC)
- **ServerConnection**: Share one `HttpTransport` for both SoliplexApi and AgUiStreamClient, remove redundant close()
- **Gains**: SSE 401 now throws `AuthException` (was generic `ApiException`), mid-stream cancel injection, less duplication
- **Docs**: Updated http-stack, agent-stack, agent-integration-guide, http-extension-guide, summary/client

## Test plan
- [x] `dart analyze --fatal-infos` passes on soliplex_client, soliplex_agent, soliplex_cli
- [x] soliplex_client: 1197 tests pass
- [x] soliplex_agent: 312 unit tests pass
- [x] soliplex_cli: 16 tests pass
- [x] Pre-commit hooks pass
- [x] Gemini 2.5-pro validated completeness against plan

**Plan:** `~/dev/soliplex-plans/http-transport-sharing-2026-03-05.md`