### PR TITLE
feat(cli): wire Monty Python execution into soliplex_cli

### DIFF
--- a/docs/architecture/agent-integration-guide.md
+++ b/docs/architecture/agent-integration-guide.md
@@ -757,7 +757,12 @@ The cleanest consumer. Demonstrates:
 - `waitAll` / `waitAny` for multi-session coordination
 - Verbose state tracing via `stateChanges` stream
 - SIGINT signal handling for graceful cancellation
+- Headless Monty execution via `--monty` flag
+- Non-interactive batch mode via `--prompt` (multiple allowed)
 - No stubs, no workarounds
+
+For CLI-specific setup, Monty integration, and troubleshooting, see
+[cli-monty-guide.md](cli-monty-guide.md).
 
 ### TUI (`soliplex_tui`)
 

--- a/docs/architecture/cli-monty-guide.md
+++ b/docs/architecture/cli-monty-guide.md
@@ -1,0 +1,185 @@
+# CLI Monty Integration Guide
+
+How to run `soliplex_cli` as a headless Monty-capable client,
+executing `execute_python` tool calls through the full Monty FFI
+pipeline without Flutter.
+
+For general agent integration patterns, see
+[agent-integration-guide.md](agent-integration-guide.md).
+
+## Prerequisites
+
+### 1. Build the native Monty library
+
+```bash
+cd /path/to/dart_monty/native
+cargo build --release
+```
+
+This produces `target/release/libdart_monty_native.dylib` (macOS) or
+the equivalent `.so` / `.dll` for your platform.
+
+### 2. Set the library path
+
+```bash
+export DART_MONTY_LIB_PATH=/path/to/dart_monty/native/target/release/libdart_monty_native.dylib
+```
+
+`NativeBindingsFfi()` requires this environment variable. Without it,
+`DynamicLibrary.open()` crashes at startup with no helpful error
+message. See [dart_monty#70](https://github.com/runyaga/dart_monty/issues/70).
+
+### 3. Start the backend server
+
+```bash
+cd /path/to/soliplex-backend
+OLLAMA_BASE_URL=http://your-ollama-host:11434 \
+  uv run soliplex-cli serve example/minimal.yaml --no-auth-mode --port 8000
+```
+
+The backend room's `prompt.txt` should instruct the LLM to use the
+`execute_python` tool rather than outputting code as text.
+
+## Usage
+
+### Single-turn execution
+
+```bash
+dart run bin/soliplex_cli.dart \
+  --host http://localhost:8000 --room my-room --monty -v \
+  --prompt "Create x = 42 and print it"
+```
+
+The process sends the prompt, waits for the LLM to call
+`execute_python`, executes the Python code through Monty FFI, returns
+the result to the LLM, and exits.
+
+### Multi-turn (sequential prompts)
+
+```bash
+dart run bin/soliplex_cli.dart \
+  --host http://localhost:8000 --room my-room --monty -v \
+  --prompt "Create a list of 3 names and print them" \
+  --prompt "How many names are in the list?"
+```
+
+Multiple `--prompt` flags run sequentially on the same server-side
+thread (`ephemeral: false`). The LLM sees the full conversation
+history from prior turns.
+
+### WASM constraint simulation
+
+```bash
+dart run bin/soliplex_cli.dart \
+  --host http://localhost:8000 --room my-room --monty --wasm-mode -v \
+  --prompt "Create x = 42 and print it"
+```
+
+`--wasm-mode` applies `WebPlatformConstraints` (single bridge, no
+reentrant interpreter) while still using native FFI. This validates
+constraint enforcement paths without requiring a browser.
+
+### Interactive REPL with Monty
+
+```bash
+dart run bin/soliplex_cli.dart \
+  --host http://localhost:8000 --room my-room --monty -v
+```
+
+Starts an interactive REPL. Type prompts at the `>` prompt. Use
+`/room <name>` to switch rooms, `/spawn` for background sessions,
+`Ctrl-C` to cancel.
+
+## How It Wires Up
+
+When `--monty` is passed, the CLI registers the Monty FFI platform
+and creates a script environment factory:
+
+```dart
+MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
+
+final envFactory = createMontyScriptEnvironmentFactory(
+  hostApi: FakeHostApi(),
+  bridgeCache: BridgeCache(limit: platform.maxConcurrentBridges),
+);
+
+final runtime = AgentRuntime(
+  bundle: bundle,
+  toolRegistryResolver: resolver,
+  platform: platform,
+  logger: logger,
+  extensionFactory: wrapScriptEnvironmentFactory(envFactory),
+);
+```
+
+`FakeHostApi` stubs chart and platform calls with auto-incrementing
+handles, making the CLI fully headless. `execute_python` tool calls
+flow through `DefaultMontyBridge` -> Monty FFI -> real Python
+execution.
+
+### Component flow
+
+```text
+CLI (--monty, ephemeral:false) -> AG-UI -> Backend -> LLM (Ollama)
+                                                        |
+                                          tool_call: execute_python
+                                                        |
+                                    CLI auto-executes via Monty FFI
+                                                        |
+                                    tool_result -> AG-UI -> LLM continues
+```
+
+## Multi-Turn State Behavior
+
+Server-side thread persistence and client-side interpreter state are
+independent concerns:
+
+| What | Controlled by | Persists across turns? |
+|------|--------------|----------------------|
+| Conversation history | `ephemeral: false` | Yes (server-side) |
+| Python variables | `DefaultMontyBridge` | No (fresh interpreter per execute) |
+| DfRegistry handles | `extensionFactory` | No (fresh environment per spawn) |
+
+Each `spawn()` creates a new `MontyScriptEnvironment` with a fresh
+`DfRegistry` and a fresh interpreter context. Python variables and
+DataFrame handles from turn 1 do not exist in turn 2.
+
+The LLM can compensate for simple state by re-declaring variables
+from conversation history (the server-side thread retains all
+messages). This works for simple cases but breaks down for complex
+computed state (DataFrames, intermediate results).
+
+### Production fix path
+
+[dart_monty#71](https://github.com/runyaga/dart_monty/issues/71)
+(S10) -- wire `MontySession` into `DefaultMontyBridge` for
+JSON-serializable Python state persistence between `execute()` calls.
+`MontySession` already exists and passes 44/44 tests, but
+`DefaultMontyBridge` does not use it yet.
+
+## Troubleshooting
+
+**`DynamicLibrary.open()` crash on startup**
+Set `DART_MONTY_LIB_PATH` to the absolute path of the native library.
+Build it with `cargo build --release` in `dart_monty/native/`.
+
+**500 error on second prompt in multi-turn**
+Known backend issue
+([soliplex#670](https://github.com/soliplex/soliplex/issues/670)).
+SSE client disconnect poisons the asyncpg connection pool. Workaround:
+add `pool_pre_ping=True` to the backend's `create_async_engine()`
+call.
+
+**Python NameError on turn 2 referencing turn 1 variables**
+Expected behavior -- `DefaultMontyBridge` creates a fresh interpreter
+per `execute()`. Python state does not persist between turns. See
+[dart_monty#71](https://github.com/runyaga/dart_monty/issues/71).
+
+**LLM outputs code as text instead of calling execute_python**
+The room's `prompt.txt` must explicitly instruct the LLM to use the
+`execute_python` tool. Small local LLMs (20B) need strong prompting
+to prefer tool calls over markdown code blocks.
+
+**`--wasm-mode` fails but native works**
+A real WASM-blocking pattern was found. Check if the code triggers
+reentrant interpreter calls or exceeds the single-bridge limit.

--- a/packages/soliplex_cli/CLAUDE.md
+++ b/packages/soliplex_cli/CLAUDE.md
@@ -11,6 +11,8 @@ dart analyze --fatal-infos
 dart test
 dart run bin/soliplex_cli.dart
 dart run bin/soliplex_cli.dart --host http://localhost:8000 --room plain
+dart run bin/soliplex_cli.dart --monty --room spike-20b
+dart run bin/soliplex_cli.dart --monty --wasm-mode --room spike-20b
 ```
 
 ## Architecture
@@ -20,12 +22,27 @@ dart run bin/soliplex_cli.dart --host http://localhost:8000 --room plain
 - `ToolDefinitions` (`buildDemoToolRegistry`) -- demo tool registry (secret_number, echo)
 - `ResultPrinter` (`formatResult`) -- formats `AgentResult` for terminal output
 
+## Monty Mode
+
+`--monty` enables the Monty Python sandbox via `extensionFactory` on `AgentRuntime`.
+Each `AgentSession` gets its own `MontyScriptEnvironment` with `DefaultMontyBridge`,
+`DfRegistry`, and `HostFunctionWiring`. When the LLM calls `execute_python` as a tool,
+`AgentSession` auto-executes it through real Monty.
+
+`--wasm-mode` uses `WebPlatformConstraints` (single bridge, no re-entrancy) to validate
+WASM compatibility.
+
+`FakeHostApi` stubs chart/platform calls for headless operation.
+
 ## Dependencies
 
 - `args` -- command-line argument parsing
 - `soliplex_agent` -- `AgentRuntime`, `AgentSession`, `AgentResult`
 - `soliplex_client` -- `SoliplexApi`, `AgUiStreamClient`, `ToolRegistry`
+- `soliplex_dataframe` -- `DfRegistry` (transitive via scripting)
+- `soliplex_interpreter_monty` -- `DefaultMontyBridge` (transitive via scripting)
 - `soliplex_logging` -- structured logging
+- `soliplex_scripting` -- `MontyScriptEnvironment`, `HostFunctionWiring`, factory functions
 
 ## Rules
 

--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_cli/src/client_factory.dart';
 import 'package:soliplex_cli/src/result_printer.dart';
@@ -9,6 +11,7 @@ import 'package:soliplex_cli/src/tool_definitions.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show DartHttpClient, SoliplexApi;
 import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:soliplex_scripting/soliplex_scripting.dart';
 
 Future<void> runCli(List<String> args) async {
   final parser = ArgParser()
@@ -41,6 +44,23 @@ Future<void> runCli(List<String> args) async {
       'tools',
       abbr: 't',
       help: 'Comma-separated tool names to advertise (default: all).',
+    )
+    ..addFlag(
+      'monty',
+      negatable: false,
+      help: 'Enable Monty Python execution (wires execute_python tool).',
+    )
+    ..addFlag(
+      'wasm-mode',
+      negatable: false,
+      help: 'Simulate WASM constraints (single bridge, no re-entrancy).',
+    )
+    ..addMultiOption(
+      'prompt',
+      abbr: 'p',
+      splitCommas: false,
+      help: 'Send prompt(s) non-interactively and exit. '
+          'Multiple --prompt flags run sequentially in the same thread.',
     );
 
   final parsed = parser.parse(args);
@@ -95,11 +115,29 @@ Future<void> _runSession(ArgResults parsed) async {
   final toolRegistry = noTools
       ? const ToolRegistry()
       : buildDemoToolRegistry(enabledTools: enabledTools);
+
+  final montyEnabled = parsed.flag('monty');
+  final wasmMode = parsed.flag('wasm-mode');
+
+  SessionExtensionFactory? extensionFactory;
+  if (montyEnabled) {
+    MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
+    final hostApi = FakeHostApi();
+    final envFactory = createMontyScriptEnvironmentFactory(
+      hostApi: hostApi,
+      limits: MontyLimitsDefaults.tool,
+    );
+    extensionFactory = wrapScriptEnvironmentFactory(envFactory);
+  }
+
   final runtime = AgentRuntime(
     connection: connection,
     toolRegistryResolver: (_) async => toolRegistry,
-    platform: const NativePlatformConstraints(),
+    platform: wasmMode
+        ? const WebPlatformConstraints()
+        : const NativePlatformConstraints(),
     logger: logger,
+    extensionFactory: extensionFactory,
   );
 
   final ctx = _CliContext(
@@ -110,14 +148,32 @@ Future<void> _runSession(ArgResults parsed) async {
   );
 
   if (verbose) stderr.writeln('[verbose mode]');
+  final toolNames = toolRegistry.toolDefinitions.map((t) => t.name).toList();
+  if (montyEnabled) toolNames.add('execute_python');
+
+  final prompts = parsed.multiOption('prompt');
+  if (prompts.isNotEmpty) {
+    // Non-interactive mode: run prompts sequentially, then exit.
+    if (verbose) {
+      stderr.writeln(
+        'soliplex-cli connected to $host (room: $room)  '
+        'tools: [${toolNames.join(', ')}]',
+      );
+    }
+    await _runPrompts(ctx, prompts);
+    await runtime.dispose();
+    await connection.close();
+    return;
+  }
+
   stdout
     ..writeln('soliplex-cli connected to $host (room: $room)')
     ..writeln(
-      toolRegistry.isEmpty
+      toolNames.isEmpty
           ? 'tools: (none)'
-          : 'tools: [${toolRegistry.toolDefinitions.map(
-                (t) => t.name,
-              ).join(', ')}]',
+          : 'tools: [${toolNames.join(', ')}]'
+              '${montyEnabled ? '  (monty: enabled)' : ''}'
+              '${wasmMode ? '  (wasm-mode)' : ''}',
     )
     ..writeln();
   _printHelp();
@@ -135,6 +191,21 @@ Future<void> _runSession(ArgResults parsed) async {
 
   await runtime.dispose();
   await connection.close();
+}
+
+/// Runs prompts sequentially in the same thread, then exits.
+Future<void> _runPrompts(_CliContext ctx, List<String> prompts) async {
+  for (var i = 0; i < prompts.length; i++) {
+    final prompt = prompts[i];
+    if (ctx.verbose) {
+      stderr.writeln('[${i + 1}/${prompts.length}] $prompt');
+    }
+    await _sendAndWait(ctx, ctx.defaultRoom, prompt);
+    // Allow session cleanup (SSE teardown) to complete before next spawn.
+    if (i < prompts.length - 1) {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+    }
+  }
 }
 
 class _CliContext {
@@ -307,16 +378,22 @@ Future<void> _sendAndWait(
     ctx.setThread(room, session.threadKey.threadId);
 
     StreamSubscription<RunState>? traceSub;
+    void Function()? eventUnsub;
     if (ctx.verbose) {
       traceSub = session.stateChanges.listen(
         _traceState,
       );
+      eventUnsub = session.lastExecutionEvent.subscribe((event) {
+        if (event == null) return;
+        _traceExecutionEvent(event);
+      });
     }
 
     final result = await session.awaitResult(
       timeout: const Duration(seconds: 120),
     );
     await traceSub?.cancel();
+    eventUnsub?.call();
     stdout.writeln(formatResult(result));
   } on Object catch (e) {
     stdout.writeln('Error: $e');
@@ -494,6 +571,24 @@ void _traceState(RunState state) {
     case CancelledState():
       stderr.writeln('[AGUI] Cancelled');
     case IdleState():
+      break;
+  }
+}
+
+void _traceExecutionEvent(ExecutionEvent event) {
+  switch (event) {
+    case ClientToolExecuting(:final toolName, :final toolCallId):
+      stderr.writeln(
+        '[TOOL] Executing $toolName  id=${_short(toolCallId)}',
+      );
+    case ClientToolCompleted(:final toolCallId, :final result, :final status):
+      final preview =
+          result.length > 200 ? '${result.substring(0, 200)}...' : result;
+      stderr.writeln(
+        '[TOOL] Completed ${_short(toolCallId)}  '
+        'status=$status  result=$preview',
+      );
+    default:
       break;
   }
 }

--- a/packages/soliplex_cli/pubspec.yaml
+++ b/packages/soliplex_cli/pubspec.yaml
@@ -8,12 +8,20 @@ environment:
 
 dependencies:
   args: ^2.4.0
+  dart_monty_ffi: ^0.6.1
+  dart_monty_platform_interface: ^0.6.1
   soliplex_agent:
     path: ../soliplex_agent
   soliplex_client:
     path: ../soliplex_client
+  soliplex_dataframe:
+    path: ../soliplex_dataframe
+  soliplex_interpreter_monty:
+    path: ../soliplex_interpreter_monty
   soliplex_logging:
     path: ../soliplex_logging
+  soliplex_scripting:
+    path: ../soliplex_scripting
 
 dev_dependencies:
   mocktail: ^1.0.0


### PR DESCRIPTION
## Summary

- Add `--monty` flag for headless `execute_python` tool execution through Monty FFI
- Add `--wasm-mode` for WASM constraint simulation (WebPlatformConstraints)
- Add `--prompt` multiOption for non-interactive batch mode (sequential prompts, same thread)
- New `docs/architecture/cli-monty-guide.md` for CLI-specific Monty setup and troubleshooting

## Changes

- **cli_runner.dart**: `--monty` registers `MontyPlatform` + `NativeBindingsFfi`, creates `MontyScriptEnvironment` via `extensionFactory` pattern, `FakeHostApi` for headless stubs
- **cli_runner.dart**: `--prompt` runs sequentially with `ephemeral: false`, `splitCommas: false`
- **cli_runner.dart**: Verbose tracing for `[TOOL] Executing` / `[TOOL] Completed` events
- **pubspec.yaml**: Added `soliplex_scripting`, `soliplex_interpreter_monty`, `soliplex_dataframe`, `dart_monty_ffi`, `dart_monty_platform_interface`
- **CLAUDE.md**: Updated with Monty-specific flags and usage
- **cli-monty-guide.md**: Prerequisites, usage, wiring, multi-turn state behavior, troubleshooting
- **agent-integration-guide.md**: CLI reference consumer section links to new guide

## Spike findings

- Single-turn Monty execution: PASS
- WASM mode: PASS
- Multi-turn: works but Python state does not persist between turns (RISK 1 — expected)
- Backend 500 on multi-turn root-caused to soliplex/soliplex#670 (SSE disconnect poisons asyncpg pool)
- Upstream issues filed: dart_monty #70-#73
- Gemini chief architect review: 8/8 PASS

## Test plan

- [x] `dart analyze --fatal-infos` — 0 issues
- [x] Single-turn: `--monty --prompt "Create x = 42 and print it"` — execute_python called, result returned
- [x] Multi-turn: two `--prompt` flags on same thread — both succeed
- [x] WASM mode: `--monty --wasm-mode --prompt "..."` — same result as native
- [x] Plan: `/Users/runyaga/dev/soliplex-plans/soliplex-cli-monty-plan-2026-03-06.md`