### PR TITLE
feat(agent): queue spawn at concurrency limit + MobilePlatformConstraints

### DIFF
--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -45,6 +45,7 @@ export 'src/host/fake_agent_api.dart';
 export 'src/host/fake_host_api.dart';
 export 'src/host/form_api.dart';
 export 'src/host/host_api.dart';
+export 'src/host/mobile_platform_constraints.dart';
 export 'src/host/native_platform_constraints.dart';
 export 'src/host/platform_constraints.dart';
 export 'src/host/runtime_agent_api.dart';

--- a/packages/soliplex_agent/lib/src/host/mobile_platform_constraints.dart
+++ b/packages/soliplex_agent/lib/src/host/mobile_platform_constraints.dart
@@ -1,0 +1,24 @@
+import 'package:soliplex_agent/src/host/platform_constraints.dart';
+
+/// Platform constraints for mobile (iOS, Android).
+///
+/// Same capabilities as native desktop but with a lower default concurrency
+/// limit to conserve memory on resource-constrained devices.
+class MobilePlatformConstraints implements PlatformConstraints {
+  /// Creates mobile platform constraints.
+  ///
+  /// [maxConcurrentBridges] defaults to 2 (conservative for mobile memory).
+  const MobilePlatformConstraints({this.maxConcurrentBridges = 2});
+
+  @override
+  bool get supportsParallelExecution => true;
+
+  @override
+  bool get supportsAsyncMode => false;
+
+  @override
+  final int maxConcurrentBridges;
+
+  @override
+  bool get supportsReentrantInterpreter => true;
+}

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -61,6 +61,7 @@ class AgentRuntime {
 
   final Map<String, AgentSession> _sessions = {};
   final Set<String> _deletedThreadIds = {};
+  final _spawnQueue = <Completer<void>>[];
   final StreamController<List<AgentSession>> _sessionController =
       StreamController<List<AgentSession>>.broadcast();
   final Signal<List<AgentSession>> _sessionsSignal = signal([]);
@@ -85,10 +86,14 @@ class AgentRuntime {
     return _sessions.values.where((s) => s.threadKey == key).firstOrNull;
   }
 
+  /// Number of spawn requests waiting for a concurrency slot.
+  int get pendingSpawnCount => _spawnQueue.length;
+
   /// Spawns a new agent session.
   ///
   /// Creates a thread (or reuses [threadId]), resolves tools for [roomId],
-  /// builds an [AgentSession], and starts the run.
+  /// builds an [AgentSession], and starts the run. If the concurrency limit
+  /// is reached, waits for a slot to open before proceeding.
   ///
   /// When [parent] is provided, the new session is registered as a child
   /// of that parent. Cancelling or disposing the parent will cascade to
@@ -103,7 +108,7 @@ class AgentRuntime {
   }) async {
     _guardNotDisposed();
     _guardWasmReentrancy();
-    _guardConcurrency();
+    await _waitForSlot();
     final (key, existingRunId) = await _resolveThread(roomId, threadId);
     final session = await _buildSession(
       key: key,
@@ -157,6 +162,10 @@ class AgentRuntime {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    for (final completer in _spawnQueue) {
+      completer.complete();
+    }
+    _spawnQueue.clear();
     await cancelAll();
     await _cleanupEphemeralThreads();
     for (final session in _sessions.values.toList()) {
@@ -183,13 +192,18 @@ class AgentRuntime {
     }
   }
 
-  void _guardConcurrency() {
-    if (_activeCount >= _platform.maxConcurrentBridges) {
-      throw StateError(
-        'Concurrency limit reached '
-        '($_activeCount / ${_platform.maxConcurrentBridges})',
-      );
-    }
+  Future<void> _waitForSlot() async {
+    if (_activeCount < _platform.maxConcurrentBridges) return;
+    final completer = Completer<void>();
+    _spawnQueue.add(completer);
+    await completer.future;
+    _guardNotDisposed();
+  }
+
+  void _drainQueue() {
+    if (_spawnQueue.isEmpty) return;
+    if (_activeCount >= _platform.maxConcurrentBridges) return;
+    _spawnQueue.removeAt(0).complete();
   }
 
   int get _activeCount =>
@@ -264,6 +278,7 @@ class AgentRuntime {
   void _removeSession(AgentSession session) {
     _sessions.remove(session.id);
     _emitSessions();
+    _drainQueue();
   }
 
   void _emitSessions() {

--- a/packages/soliplex_agent/test/host/platform_constraints_test.dart
+++ b/packages/soliplex_agent/test/host/platform_constraints_test.dart
@@ -61,6 +61,33 @@ void main() {
     });
   });
 
+  group('MobilePlatformConstraints', () {
+    test('supports parallel execution', () {
+      const constraints = MobilePlatformConstraints();
+      expect(constraints.supportsParallelExecution, isTrue);
+    });
+
+    test('defaults to 2 max concurrent bridges', () {
+      const constraints = MobilePlatformConstraints();
+      expect(constraints.maxConcurrentBridges, equals(2));
+    });
+
+    test('accepts custom max concurrent bridges', () {
+      const constraints = MobilePlatformConstraints(maxConcurrentBridges: 3);
+      expect(constraints.maxConcurrentBridges, equals(3));
+    });
+
+    test('supports reentrant interpreter', () {
+      const constraints = MobilePlatformConstraints();
+      expect(constraints.supportsReentrantInterpreter, isTrue);
+    });
+
+    test('implements PlatformConstraints', () {
+      const PlatformConstraints constraints = MobilePlatformConstraints();
+      expect(constraints, isA<PlatformConstraints>());
+    });
+  });
+
   group('PlatformConstraints interface', () {
     test('native and web have opposite parallel support', () {
       const native = NativePlatformConstraints();

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -365,10 +365,10 @@ void main() {
     });
   });
 
-  group('concurrency guard', () {
-    test('blocks spawn at max concurrent limit', () async {
+  group('concurrency queuing', () {
+    test('queues spawn at max concurrent limit', () async {
       runtime = createRuntime(
-        platform: const NativePlatformConstraints(maxConcurrentBridges: 2),
+        platform: const NativePlatformConstraints(maxConcurrentBridges: 1),
       );
 
       stubCreateThread();
@@ -378,15 +378,89 @@ void main() {
       stubRunAgent(stream: controller.stream);
 
       await runtime.spawn(roomId: _roomId, prompt: 'A');
-      await runtime.spawn(roomId: _roomId, prompt: 'B');
+      expect(runtime.pendingSpawnCount, 0);
+
+      // Second spawn should queue, not throw.
+      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      // Let microtask run so _waitForSlot enqueues.
+      await Future<void>.delayed(Duration.zero);
+      expect(runtime.pendingSpawnCount, 1);
+
+      // Complete first session to free the slot.
+      _happyPathEvents().forEach(controller.add);
+      await controller.close();
+
+      // Give time for session completion + queue drain.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Queued spawn needs a fresh stream.
+      final controller2 = StreamController<BaseEvent>.broadcast();
+      stubRunAgent(stream: controller2.stream);
+
+      final session = await spawnFuture;
+      expect(session, isNotNull);
+      expect(runtime.pendingSpawnCount, 0);
+
+      // Clean up
+      _happyPathEvents().forEach(controller2.add);
+      await controller2.close();
+    });
+
+    test('dispose unblocks queued spawns with StateError', () async {
+      runtime = createRuntime(
+        platform: const NativePlatformConstraints(maxConcurrentBridges: 1),
+      );
+
+      stubCreateThread();
+      stubCreateRun();
+      stubDeleteThread();
+      final controller = StreamController<BaseEvent>.broadcast();
+      stubRunAgent(stream: controller.stream);
+
+      await runtime.spawn(roomId: _roomId, prompt: 'A');
+
+      // Queue a second spawn and immediately attach an error handler
+      // so the test zone doesn't see an unhandled rejection.
+      Object? caught;
+      final spawnFuture = runtime.spawn(roomId: _roomId, prompt: 'B');
+      unawaited(
+        spawnFuture.then<void>((_) {}).catchError((Object e) {
+          caught = e;
+        }),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(runtime.pendingSpawnCount, 1);
+
+      // Complete first session and dispose runtime.
+      _happyPathEvents().forEach(controller.add);
+      await controller.close();
+      await runtime.dispose();
+
+      // Let microtasks settle.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(caught, isA<StateError>());
+    });
+
+    test('WASM reentrant guard still throws immediately', () async {
+      runtime = createRuntime(
+        platform: const WebPlatformConstraints(),
+      );
+
+      stubCreateThread();
+      stubCreateRun();
+      stubDeleteThread();
+      final controller = StreamController<BaseEvent>.broadcast();
+      stubRunAgent(stream: controller.stream);
+
+      await runtime.spawn(roomId: _roomId, prompt: 'A');
 
       expect(
-        () => runtime.spawn(roomId: _roomId, prompt: 'C'),
+        () => runtime.spawn(roomId: _roomId, prompt: 'B'),
         throwsA(
           isA<StateError>().having(
             (e) => e.message,
             'message',
-            contains('Concurrency limit'),
+            contains('WASM'),
           ),
         ),
       );


### PR DESCRIPTION
## Summary
- `AgentRuntime.spawn()` now queues instead of throwing when `maxConcurrentBridges` is reached
- New `MobilePlatformConstraints` class (defaults to 2 concurrent bridges for mobile memory)
- WASM reentrant guard still throws immediately (deadlock risk, no queuing)

## Changes
- **agent_runtime.dart**: Replace `_guardConcurrency` throw with `_waitForSlot`/`_drainQueue` completer-based FIFO queue. Dispose unblocks all waiters with StateError.
- **mobile_platform_constraints.dart**: New class, same capabilities as native but `maxConcurrentBridges=2`
- **agent_runtime_test.dart**: 3 new tests (queuing, dispose-unblock, WASM guard)
- **platform_constraints_test.dart**: 5 new tests for MobilePlatformConstraints

## Test plan
- [x] `dart format . --set-exit-if-changed` — 0 changes
- [x] `dart analyze --fatal-infos` — 0 issues
- [x] 319 unit tests pass (excluding integration tests requiring server)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)