### PR TITLE
docs: add backend room configs and SSE close analysis

### DIFF
--- a/docs/room-conf/accumulator.yaml
+++ b/docs/room-conf/accumulator.yaml
@@ -1,0 +1,12 @@
+id: "accumulator"
+name: "Accumulator Test"
+description: "Multi-turn context retention across tool calls"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a memory assistant. When the user gives you facts, acknowledge
+    them briefly. When asked to recall, list ALL facts accurately from
+    the conversation history. Do not make up facts.
+allow_mcp: false

--- a/docs/room-conf/advocate.yaml
+++ b/docs/room-conf/advocate.yaml
@@ -1,0 +1,12 @@
+id: "advocate"
+name: "Advocate Test"
+description: "Argues in favor of a position for debate tests"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a passionate advocate. Argue strongly IN FAVOR of whatever
+    topic the user presents. Give 3 compelling points. Be persuasive
+    but concise — no more than 3 sentences.
+allow_mcp: false

--- a/docs/room-conf/analysis.yaml
+++ b/docs/room-conf/analysis.yaml
@@ -1,0 +1,11 @@
+id: "analysis"
+name: "Analysis"
+description: "Search and analyze documents with code execution"
+suggestions:
+  - "Analyze the data in the documents"
+  - "Compare metrics across documents"
+agent:
+  kind: "haiku_chat"
+  rag_lancedb_stem: "rag"
+  rag_features: ["search", "analysis"]
+allow_mcp: false

--- a/docs/room-conf/chat.yaml
+++ b/docs/room-conf/chat.yaml
@@ -1,0 +1,23 @@
+id: "chat"
+name: "Haiku Chat"
+description: "Conversational RAG with search, ask, and document retrieval"
+suggestions:
+  - "Get the document agents.md and summarize its key points"
+  - "Search for information about Soliplex"
+  - "Explain how the authentication system works"
+agent:
+  kind: "haiku_chat"
+  rag_lancedb_stem: "rag"
+  rag_features: ["search", "documents", "qa"]
+  background_context: |
+    **Soliplex** is an AI-powered Retrieval-Augmented Generation (RAG) platform.
+    It lets users:
+
+    * **Index** documents (text, PDFs, etc.) in a vector store (via LanceDB).
+    * **Search** that content quickly with a full-text + vector engine.
+    * **Generate** answers that are grounded in the indexed material by calling the OpenAI API or running local Ollama models.
+    * **Interact** through a WebSocket-driven chat interface, with a FastAPI backend managing routing to the vector store and language model.
+    * **Securely authenticate** users with OIDC.
+
+    Soliplex is built on the haiku-rag library and is ideal for applications such as internal knowledge bases, legal compliance, onboarding, customer support, and research assistance.
+allow_mcp: false

--- a/docs/room-conf/classifier.yaml
+++ b/docs/room-conf/classifier.yaml
@@ -1,0 +1,14 @@
+id: "classifier"
+name: "Classifier Test"
+description: "Classifies intent for dynamic room routing"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a request classifier. Analyze the user's message and respond
+    with EXACTLY one of these room names, nothing else:
+    - "echo" for simple conversation
+    - "tool-call" for requests involving tools or data lookup
+    - "parallel" for requests involving multiple concurrent tasks
+allow_mcp: false

--- a/docs/room-conf/critic.yaml
+++ b/docs/room-conf/critic.yaml
@@ -1,0 +1,12 @@
+id: "critic"
+name: "Critic Test"
+description: "Argues against a position for debate tests"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a sharp critic. Argue strongly AGAINST the provided argument.
+    Point out flaws and weaknesses in 3 counterpoints. Be incisive
+    but concise — no more than 3 sentences.
+allow_mcp: false

--- a/docs/room-conf/debate-advocate.yaml
+++ b/docs/room-conf/debate-advocate.yaml
@@ -1,0 +1,20 @@
+id: "debate-advocate"
+name: "Debate Advocate"
+description: "Argues passionately FOR a position in a structured debate"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a passionate debate advocate. When given a topic, argue
+    strongly IN FAVOR of it.
+
+    Format your response as:
+    **Opening:** One punchy thesis statement.
+    **Point 1:** Your strongest argument (2 sentences max).
+    **Point 2:** A supporting argument (2 sentences max).
+    **Point 3:** An emotional or ethical appeal (2 sentences max).
+
+    When given a rebuttal to respond to, defend your strongest point
+    in 2 sentences. Be persuasive, concise, and confident.
+allow_mcp: false

--- a/docs/room-conf/debate-critic.yaml
+++ b/docs/room-conf/debate-critic.yaml
@@ -1,0 +1,18 @@
+id: "debate-critic"
+name: "Debate Critic"
+description: "Argues sharply AGAINST a position in a structured debate"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are an incisive debate critic. When given arguments FOR a
+    position, argue strongly AGAINST them.
+
+    Format your response as:
+    **Rebuttal 1:** Counter the strongest point (2 sentences max).
+    **Rebuttal 2:** Expose a logical flaw (2 sentences max).
+    **Rebuttal 3:** Present a counter-example or data (2 sentences max).
+
+    Be sharp, factual, and concise. Attack the arguments, not the person.
+allow_mcp: false

--- a/docs/room-conf/debate-judge.yaml
+++ b/docs/room-conf/debate-judge.yaml
@@ -1,0 +1,20 @@
+id: "debate-judge"
+name: "Debate Judge"
+description: "Renders a verdict after reviewing both sides of a debate"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are an impartial debate judge. You will receive arguments
+    from an ADVOCATE (for) and a CRITIC (against), plus a rebuttal.
+
+    Render your verdict in this format:
+    **Winner:** ADVOCATE or CRITIC
+    **Score:** X-Y (out of 10 each)
+    **Reasoning:** 2-3 sentences explaining which arguments were
+    strongest and why.
+    **Key moment:** The single most persuasive point from either side.
+
+    Be fair, cite specific arguments, and explain your reasoning.
+allow_mcp: false

--- a/docs/room-conf/demo-synthesizer.yaml
+++ b/docs/room-conf/demo-synthesizer.yaml
@@ -1,0 +1,18 @@
+id: "demo-synthesizer"
+name: "Demo Synthesizer"
+description: "Merges multiple agent outputs into a coherent summary"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a synthesis agent. You receive outputs from multiple
+    other agents and combine them into a single coherent result.
+
+    Rules:
+    - Preserve key information from ALL inputs
+    - Resolve contradictions by noting both perspectives
+    - Output a clean, well-structured paragraph (3-5 sentences)
+    - Start with the most important finding
+    - End with actionable insight if applicable
+allow_mcp: false

--- a/docs/room-conf/dispatch.yaml
+++ b/docs/room-conf/dispatch.yaml
@@ -1,0 +1,12 @@
+id: "dispatch"
+name: "Conditional Dispatch Test"
+description: "Agent that selects correct tools from a compound request"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You have access to tools: tool_a, tool_b, tool_c.
+    Call ONLY the tools the user explicitly requests. Do not call extra tools.
+    After getting results, summarize what each tool returned.
+allow_mcp: false

--- a/docs/room-conf/echo.yaml
+++ b/docs/room-conf/echo.yaml
@@ -1,0 +1,9 @@
+id: "echo"
+name: "Echo Test"
+description: "Simple text response, no tools"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: "You are a concise test assistant. Reply in one sentence."
+allow_mcp: false

--- a/docs/room-conf/faux.yaml
+++ b/docs/room-conf/faux.yaml
@@ -1,0 +1,10 @@
+id: "faux"
+name: "Faux Agent Test"
+description: "Testing faux agent"
+agent:
+  kind: "factory"
+  factory_name: "soliplex.examples.faux_agent_factory"
+  with_agent_config: true
+tools:
+  - tool_name: "soliplex.examples.faux_tool"
+allow_mcp: false

--- a/docs/room-conf/fixer.yaml
+++ b/docs/room-conf/fixer.yaml
@@ -1,0 +1,11 @@
+id: "fixer"
+name: "Fixer Test"
+description: "Fixes text based on reviewer feedback for pipeline recovery"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a text fixer. You receive a draft and a critique. Apply the
+    feedback to produce an improved version. Keep it concise — 1-3 sentences.
+allow_mcp: false

--- a/docs/room-conf/gemini_flash.yaml
+++ b/docs/room-conf/gemini_flash.yaml
@@ -1,0 +1,18 @@
+id: "gemini_flash"
+name: "Gemini 2.5 Flash"
+description: "Chat with Google Gemini 2.5 Flash"
+suggestions:
+  - "What time is it?"
+  - "Who am I?"
+  - "Tell me a fun fact about space"
+agent:
+  model_name: "gemini-2.5-flash"
+  provider_type: "google"
+  provider_key: "secret:GEMINI_API_KEY"
+  system_prompt: |
+    You are a friendly agent with enthusiasm for space travel.
+allow_mcp: true
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+    allow_mcp: true
+  - tool_name: "soliplex.tools.get_current_user"

--- a/docs/room-conf/genui.yaml
+++ b/docs/room-conf/genui.yaml
@@ -1,0 +1,41 @@
+id: "genui"
+name: "genui"
+description: "test genui"
+suggestions:
+- "What is the weather in <your location>?"
+
+# NOTE: Canvas state sync requires custom factory agent (see genui.py)
+# but it's currently broken. Using default_chat for now.
+# See BACKEND-REQUEST.md for investigation notes.
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+  - tool_name: "soliplex.tools.agui_state"
+
+#mcp_client_toolsets:
+
+  #smithery_nws:
+  #  kind: "http"
+  #  url: "https://server.smithery.ai/@smithery-ai/national-weather-service/mcp"
+  #  allowed_tools:
+  #  - "get_current_weather"
+
+  #  query_params:
+  #    # This is bog stupid:  the SmitheryAI endpoint does not support
+  #    # passing an 'Authorization: Bearer <API KEY>' header, but instead
+  #    # expects to have the values passed in the query string (unless the
+  #    # client can do the full OAuth2 flow).
+  #    api_key: "secret:SMITHERY_AI_API_KEY"
+  #    profile: "secret:SMITHERY_AI_PROFILE"
+
+# google_maps:
+#   kind: "stdio"
+#   command: "npx"
+#   args:
+#     - "-y"
+#     - "@modelcontextprotocol/server-google-maps"
+#   env:
+#     GOOGLE_MAPS_API_KEY: "secret:GOOGLE_MAPS_API_KEY"

--- a/docs/room-conf/joker.yaml
+++ b/docs/room-conf/joker.yaml
@@ -1,0 +1,8 @@
+id: "joker"
+name: "Joke generator"
+description: "Testing agent delegation"
+agent:
+  kind: "factory"
+  factory_name: "soliplex.examples.joker_agent_factory"
+  with_agent_config: true
+allow_mcp: false

--- a/docs/room-conf/judge.yaml
+++ b/docs/room-conf/judge.yaml
@@ -1,0 +1,12 @@
+id: "judge"
+name: "Judge Test"
+description: "Evaluates and picks consensus from multiple inputs"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are an impartial judge. Review the provided opinions or arguments
+    and determine the consensus or strongest position. State your verdict
+    clearly in 1-2 sentences, citing which side you agree with and why.
+allow_mcp: false

--- a/docs/room-conf/mcptest.yaml
+++ b/docs/room-conf/mcptest.yaml
@@ -1,0 +1,23 @@
+id: "mcptest"
+name: "MCP Test"
+description: "Test MCP tool interaction."
+suggestions:
+- "What is the weather in <your location>?"
+
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+
+mcp_client_toolsets:
+
+  google_maps:
+    kind: "stdio"
+    command: "npx"
+    args: 
+      - "-y"
+      - "@modelcontextprotocol/server-google-maps"
+    env: 
+      GOOGLE_MAPS_API_KEY: secret:GOOGLE_MAPS_API_KEY

--- a/docs/room-conf/monty.yaml
+++ b/docs/room-conf/monty.yaml
@@ -1,0 +1,11 @@
+id: "monty"
+name: "Monty Python Sandbox"
+description: "Write and execute sandboxed Python with DataFrame and charting tools"
+suggestions:
+  - "Create a DataFrame of the top 5 cities by population and chart it"
+  - "Compute the Fibonacci sequence up to 20 and plot it"
+  - "Analyze this CSV data and show me a scatter plot"
+agent:
+  template_id: "default_chat"
+  system_prompt: "./prompt.txt"
+allow_mcp: false

--- a/docs/room-conf/multi-tool.yaml
+++ b/docs/room-conf/multi-tool.yaml
@@ -1,0 +1,14 @@
+id: "multi-tool"
+name: "Multi Tool Test"
+description: "Agent that chains multiple tool calls"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You have access to multiple tools. When asked to run diagnostics,
+    call get_current_datetime first, then call system_status, then
+    summarize both results.
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+allow_mcp: false

--- a/docs/room-conf/parallel.yaml
+++ b/docs/room-conf/parallel.yaml
@@ -1,0 +1,10 @@
+id: "parallel"
+name: "Parallel Test"
+description: "Room for concurrent agent sessions"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    Reply with exactly the word the user asks you to say, nothing else.
+allow_mcp: false

--- a/docs/room-conf/plain.yaml
+++ b/docs/room-conf/plain.yaml
@@ -1,0 +1,13 @@
+id: "plain"
+name: "Plain Chat"
+description: "Simple helpful assistant"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are helpful.
+allow_mcp: false
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+  - tool_name: "soliplex.tools.get_current_user"

--- a/docs/room-conf/planner.yaml
+++ b/docs/room-conf/planner.yaml
@@ -1,0 +1,12 @@
+id: "planner"
+name: "Planner Test"
+description: "Decomposes tasks into subtasks for fan-out"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a task planner. Break the user's request into subtasks.
+    Output ONLY a valid JSON array of strings, no markdown formatting,
+    no explanations. Example: ["subtask 1", "subtask 2", "subtask 3"]
+allow_mcp: false

--- a/docs/room-conf/quiztest.yaml
+++ b/docs/room-conf/quiztest.yaml
@@ -1,0 +1,16 @@
+id: "quiztest"
+name: "Quiz testing"
+description: "Quiz testing."
+logo_image: "./jeopardy.png"
+agent:
+  template_id: "default_chat"
+  system_prompt: "UNUSED, see quiz config"
+quizzes:
+  - id: "test_quiz"
+    question_file: "test_quiz"
+    title: "Test Quiz"
+    randomize: True
+    max_questions: 20
+    judge_agent:
+      id: "test_quiz_judge"
+      template_id: "alternate_chat"

--- a/docs/room-conf/reviewer.yaml
+++ b/docs/room-conf/reviewer.yaml
@@ -1,0 +1,12 @@
+id: "reviewer"
+name: "Reviewer Test"
+description: "Reviews and critiques text for pipeline tests"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a strict reviewer. Critique the provided text in one sentence.
+    If the text meets all requirements, reply with exactly "PASS".
+    Otherwise reply with "FAIL: " followed by your critique.
+allow_mcp: false

--- a/docs/room-conf/search.yaml
+++ b/docs/room-conf/search.yaml
@@ -1,0 +1,14 @@
+id: "search"
+name: "Search & Answer"
+description: "Search the knowledge base and answer questions"
+suggestions:
+  - "What is a Soliplex installation?"
+  - "Find documents about authentication"
+agent:
+  kind: "haiku_chat"
+  rag_lancedb_stem: "rag"
+  rag_features: ["search"]
+  preamble: |
+    You are a knowledgeable assistant that answers questions using a document knowledge base.
+    Use search to find relevant information, then synthesize a comprehensive answer.
+allow_mcp: false

--- a/docs/room-conf/searcher.yaml
+++ b/docs/room-conf/searcher.yaml
@@ -1,0 +1,13 @@
+id: "searcher"
+name: "Searcher Test"
+description: "Iterative tool refinement loop"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You have a 'search_db' tool. Use it to find what the user asks for.
+    If the tool returns "Not found", refine your query and search again.
+    Keep searching with different queries until you get a result.
+    Report the final result to the user.
+allow_mcp: false

--- a/docs/room-conf/strict-tool.yaml
+++ b/docs/room-conf/strict-tool.yaml
@@ -1,0 +1,13 @@
+id: "strict-tool"
+name: "Strict Tool Test"
+description: "Tests tool argument fidelity and failure recovery"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You have a 'calculate' tool that takes structured arguments.
+    When asked to calculate something, call the tool with the correct
+    arguments. If the tool returns an error, adjust your arguments
+    and try again. Do not give up after one failure.
+allow_mcp: false

--- a/docs/room-conf/tool-call.yaml
+++ b/docs/room-conf/tool-call.yaml
@@ -1,0 +1,13 @@
+id: "tool-call"
+name: "Tool Call Test"
+description: "Agent that calls a client-side tool"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You have access to tools. When asked for a secret number, you MUST
+    call the secret_number tool and report its result. Always use the tool.
+tools:
+  - tool_name: "soliplex.tools.get_current_datetime"
+allow_mcp: false

--- a/docs/room-conf/writer.yaml
+++ b/docs/room-conf/writer.yaml
@@ -1,0 +1,11 @@
+id: "writer"
+name: "Writer Test"
+description: "Generates draft text for pipeline tests"
+agent:
+  model_name: "gpt-oss:20b"
+  provider_type: "ollama"
+  provider_base_url: "http://workshop:11434"
+  system_prompt: |
+    You are a creative writer. Write concise, focused text about whatever
+    the user requests. Keep responses to 1-3 sentences unless asked for more.
+allow_mcp: false

--- a/docs/sse-close-analysis.md
+++ b/docs/sse-close-analysis.md
@@ -1,0 +1,331 @@
+# SSE Stream Close Reported as Error — Analysis
+
+## Symptom
+
+When the CLI connects to the datetime room and completes a successful run, the
+verbose output shows:
+
+```text
+[AGUI] Completed  run=75569356-...  msgs=2  tools=1
+[AGUI]   last: TextMessage(...)
+[c950f8ad-...] SUCCESS: The current date and time is: 2026-03-04T19:28:19...
+> [SSE] END ERROR (6816ms, 3050B)
+[cleanup] SSE stream disconnect (ignored)
+```
+
+The run completes successfully (we get the answer), but the SSE stream close is
+logged as `[SSE] END ERROR` instead of `[SSE] END OK`.
+
+## How SSE Works
+
+SSE (Server-Sent Events) is a one-way streaming protocol. The server sends
+events over a long-lived HTTP connection, then **closes the connection** when
+done. This close is *normal protocol behavior*, not an error. The AG-UI
+protocol uses SSE: the server streams run events, then closes the connection
+after sending the final `RunFinished` event.
+
+## Root Cause Chain
+
+### Layer 1: `DartHttpClient.requestStream()` (dart_http_client.dart:114-187)
+
+```dart
+subscription = streamedResponse.stream.listen(
+  controller.add,
+  onError: (Object error, StackTrace stackTrace) {
+    // Wrap all stream errors as NetworkException
+    controller.addError(
+      NetworkException(
+        message: 'Stream error: $error',
+        originalError: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  },
+  onDone: controller.close,
+  cancelOnError: true,    // <-- KEY PROBLEM
+);
+```
+
+The `http` package (dart:io or browser) surfaces the server closing the TCP
+connection as a stream **error** (likely `ClientException: Connection closed
+while receiving data`), not a clean stream **done**.
+
+With `cancelOnError: true`:
+
+1. The error fires → `onError` handler wraps it as `NetworkException` and adds
+   to the controller
+2. The subscription auto-cancels immediately
+3. `onDone` **never fires** because `cancelOnError` killed the subscription
+
+So the controller emits an error but is never properly closed through the done
+path.
+
+### Layer 2: `ObservableHttpClient.requestStream()` (observable_http_client.dart:152-249)
+
+The `StreamTransformer.fromHandlers` has two paths:
+
+- `handleError` (line 201): Fires `onStreamEnd` with `error: soliplexError` →
+  `isSuccess = false`
+- `handleDone` (line 229): Fires `onStreamEnd` with `error: null` →
+  `isSuccess = true`
+
+Because the error path fires (from Layer 1), observers see `isSuccess = false`.
+
+### Layer 3: `DebugHttpObserver.onStreamEnd()` (debug_observer.dart:35-41)
+
+```dart
+void onStreamEnd(HttpStreamEndEvent event) {
+  final status = event.isSuccess ? 'OK' : 'ERROR';
+  stderr.writeln('[SSE] END $status ...');
+}
+```
+
+Prints `[SSE] END ERROR` because `isSuccess` is `false`.
+
+### Layer 4: `cli_runner.dart` runZonedGuarded (line 51-60)
+
+The `NetworkException` propagates as an unhandled async error, caught by the
+guarded zone:
+
+```dart
+(e, _) {
+  if (e.toString().contains('Connection closed')) {
+    stderr.writeln('[cleanup] SSE stream disconnect (ignored)');
+  } else {
+    stderr.writeln('[async error] $e');
+  }
+}
+```
+
+This is a band-aid — it catches and ignores the error, but the damage (false
+`[SSE] END ERROR` logging) already happened upstream.
+
+## The Two Interacting Problems
+
+1. **`cancelOnError: true`** in `DartHttpClient.requestStream()` — When the
+   `http` package emits a stream error on connection close, `cancelOnError`
+   prevents `onDone` from ever firing. The controller gets an error added but
+   is never closed cleanly. This means the downstream `handleDone` in
+   `ObservableHttpClient` never fires.
+
+2. **No distinction between "server closed connection" and "real network
+   error"** — The `onError` handler in `DartHttpClient` wraps ALL errors as
+   `NetworkException('Stream error: ...')` without checking if the error is
+   just a normal SSE connection close. A server closing the connection after
+   sending all events is protocol-correct behavior, not a network failure.
+
+## Proposed Fix Options
+
+### Option A: Change `cancelOnError` to `false` + close controller after error
+
+In `DartHttpClient.requestStream()`, change `cancelOnError: false` so that
+`onDone` still fires after an error. The stream will emit the error AND then
+complete normally. The `handleDone` in `ObservableHttpClient` will fire and
+report `isSuccess = true`.
+
+**Risk**: If a real network error occurs mid-stream, we'd continue listening
+instead of stopping. We'd need the consumer to handle errors properly.
+
+### Option B: Detect "connection closed" errors as clean completion
+
+In `DartHttpClient.requestStream()`, check the error message in `onError`. If
+it matches known "connection closed" patterns from dart:io / browser HTTP, treat
+it as a clean close:
+
+```dart
+onError: (Object error, StackTrace stackTrace) {
+  if (_isConnectionClosedError(error)) {
+    // Server closed SSE connection — this is normal.
+    controller.close();
+    return;
+  }
+  // Real error — propagate.
+  controller.addError(
+    NetworkException(
+      message: 'Stream error: $error',
+      originalError: error,
+      stackTrace: stackTrace,
+    ),
+  );
+},
+```
+
+**Risk**: Relies on string matching error messages, which is fragile across
+platforms and `http` package versions.
+
+### Option C: Handle at ObservableHttpClient layer
+
+In `ObservableHttpClient.requestStream()`, change the `handleError` to detect
+connection-closed errors and report them as successful stream ends:
+
+```dart
+handleError: (error, stackTrace, sink) {
+  final endTime = DateTime.now();
+  final duration = endTime.difference(startTime);
+  final isConnectionClosed = _isConnectionClosedError(error);
+
+  _notifyObservers((observer) {
+    observer.onStreamEnd(
+      HttpStreamEndEvent(
+        requestId: requestId,
+        timestamp: endTime,
+        bytesReceived: bytesReceived,
+        duration: duration,
+        error: isConnectionClosed ? null : (error is SoliplexException ...),
+        body: ...,
+      ),
+    );
+  });
+
+  if (!isConnectionClosed) {
+    sink.addError(error, stackTrace);
+  } else {
+    sink.close();
+  }
+},
+```
+
+### Option D: Fix at DartHttpClient — close controller after error
+
+After adding the error to the controller in `onError`, also close the
+controller. And remove `cancelOnError: true` or change it to `false`:
+
+```dart
+onError: (Object error, StackTrace stackTrace) {
+  controller.addError(
+    NetworkException(
+      message: 'Stream error: $error',
+      originalError: error,
+      stackTrace: stackTrace,
+    ),
+  );
+  // Close the controller since the stream is done (error or not)
+  controller.close();
+},
+cancelOnError: false,
+```
+
+This ensures `handleDone` always fires after any error, and the controller is
+always properly closed. The error still propagates to consumers, but the
+observable layer also gets a clean `handleDone`.
+
+**However**, this means `handleDone` AND `handleError` both fire for the same
+stream — `onStreamEnd` would be called twice.
+
+## Proposed Test
+
+A unit test that verifies a stream that errors with "Connection closed" still
+reports `isSuccess = true` to observers:
+
+```dart
+test('SSE stream close after data reports isSuccess true', () async {
+  // Simulate: server sends SSE data then closes connection (http package
+  // surfaces this as a stream error, not a clean done).
+  final sourceController = StreamController<List<int>>();
+
+  when(
+    () => mockClient.requestStream(any(), any(),
+        headers: any(named: 'headers'), body: any(named: 'body')),
+  ).thenAnswer((_) => sourceController.stream);
+
+  final stream = observableClient.requestStream('POST', testUri);
+  final received = <List<int>>[];
+  final errors = <Object>[];
+
+  stream.listen(
+    received.add,
+    onError: errors.add,
+    onDone: () {},
+  );
+
+  // Server sends SSE data
+  sourceController.add('data: hello\n\n'.codeUnits);
+  await Future<void>.delayed(Duration.zero);
+
+  // Server closes connection — http package reports as error
+  sourceController.addError(
+    NetworkException(message: 'Connection closed while receiving data'),
+  );
+  await Future<void>.delayed(Duration.zero);
+
+  // The observer should report this as a successful stream end
+  final endEvents = recorder.eventsOfType<HttpStreamEndEvent>();
+  expect(endEvents, hasLength(1));
+  expect(endEvents.first.isSuccess, isTrue,
+      reason: 'SSE connection close is normal protocol behavior');
+  expect(endEvents.first.bytesReceived, greaterThan(0));
+});
+```
+
+## Both HTTP Clients Have the Same Bug
+
+### DartHttpClient (dart_http_client.dart:145-159) — used on web/generic
+
+```dart
+subscription = streamedResponse.stream.listen(
+  controller.add,
+  onError: (Object error, StackTrace stackTrace) {
+    controller.addError(
+      NetworkException(message: 'Stream error: $error', ...),
+    );
+  },
+  onDone: controller.close,
+  cancelOnError: true,  // <-- BUG
+);
+```
+
+### CupertinoHttpClient (cupertino_http_client.dart:156-173) — used on iOS/macOS
+
+```dart
+subscription = streamedResponse.stream.listen(
+  controller.add,
+  onError: (Object error, StackTrace stackTrace) {
+    if (error is http.ClientException) {
+      controller.addError(
+        NetworkException(message: 'Connection error: ${error.message}', ...),
+      );
+    } else {
+      controller.addError(error, stackTrace);
+    }
+  },
+  onDone: controller.close,
+  cancelOnError: true,  // <-- SAME BUG
+);
+```
+
+Both implementations share the identical structural problem:
+1. `cancelOnError: true` prevents `onDone` from firing after an error
+2. Neither distinguishes "server closed connection" from "real network error"
+3. The Cupertino version has slightly better error typing (checks for
+   `ClientException`) but still treats connection close as an error
+
+The `cupertino_http` package (using NSURLSession) may surface the connection
+close differently than dart:io's `http` package, but both go through the same
+`cancelOnError: true` path. Whether NSURLSession treats a server-initiated
+TCP close as an error or a clean completion would need to be tested on device.
+
+## Files Involved
+
+| File | Role |
+|------|------|
+| `packages/soliplex_client/lib/src/http/dart_http_client.dart` | Creates the stream, sets `cancelOnError: true`, wraps errors |
+| `packages/soliplex_client_native/lib/src/clients/cupertino_http_client.dart` | Same pattern as DartHttpClient but using NSURLSession |
+| `packages/soliplex_client/lib/src/http/observable_http_client.dart` | Intercepts stream events, notifies observers, sets `isSuccess` |
+| `packages/soliplex_client/lib/src/http/http_observer.dart` | Defines `HttpStreamEndEvent.isSuccess` (line 278) |
+| `packages/soliplex_client/lib/src/errors/exceptions.dart` | `NetworkException` class |
+| `packages/soliplex_cli/lib/src/debug_observer.dart` | Prints `[SSE] END ERROR` based on `isSuccess` |
+| `packages/soliplex_cli/lib/src/cli_runner.dart` | `runZonedGuarded` band-aid for connection close errors |
+| `packages/soliplex_client/test/http/observable_http_client_test.dart` | Existing observer tests (add new test here) |
+| `packages/soliplex_client/test/http/http_client_adapter_test.dart` | Existing adapter tests |
+
+## Questions for Review
+
+1. Which fix option (A/B/C/D) is cleanest given that SSE connections ALWAYS
+   close after a run?
+2. Should the fix be in `DartHttpClient` (lowest layer) or
+   `ObservableHttpClient` (observer layer)?
+3. Is string-matching "Connection closed" fragile, or is there a better way to
+   distinguish "server closed connection normally" from "network dropped"?
+4. Should `cancelOnError` be `true` or `false` for SSE streams? The semantics
+   differ: `true` means "stop on first error" which is wrong for SSE close,
+   `false` means "keep listening after errors" which could mask real failures.


### PR DESCRIPTION
## Summary
- Add 31 backend room configuration YAMLs (`docs/room-conf/`) for reference
- Add SSE close analysis doc explaining TCP RST behavior after RUN_FINISHED

## Changes
- **`docs/room-conf/`**: 31 YAML files copied from backend `example/rooms/`
- **`docs/sse-close-analysis.md`**: Root cause analysis of the `[SSE] END ERROR` seen after successful runs — cosmetic, no data loss

## Test plan
- [x] Pre-commit hooks pass (yaml, markdown lint, dart analyze)
- [x] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)