### PR TITLE
fix(scripting): per-session MontyPlatform to fix FFI re-entrancy

### DIFF
--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dart_monty_ffi/dart_monty_ffi.dart';
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
+    show MontyPlatform;
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_cli/src/client_factory.dart';
 import 'package:soliplex_cli/src/result_printer.dart';
@@ -72,12 +73,9 @@ Future<void> runCli(List<String> args) async {
     return;
   }
 
-  await runZonedGuarded(
-    () => _runSession(parsed),
-    (e, _) {
-      stderr.writeln('[async error] $e');
-    },
-  );
+  await runZonedGuarded(() => _runSession(parsed), (e, _) {
+    stderr.writeln('[async error] $e');
+  });
 }
 
 Future<void> _runSession(ArgResults parsed) async {
@@ -124,7 +122,10 @@ Future<void> _runSession(ArgResults parsed) async {
   // reference when sessions are spawned (not at construction time).
   AgentApi? agentApi;
   if (montyEnabled) {
-    MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
+    if (wasmMode) {
+      // Retain global singleton for simulated WASM (single bridge).
+      MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
+    }
     final hostApi = FakeHostApi(
       invokeHandler: (name, args) async {
         if (name == 'log') {
@@ -140,12 +141,15 @@ Future<void> _runSession(ArgResults parsed) async {
     );
     final blackboardApi = DirectBlackboardApi();
     final fetchClient = DartHttpClient();
+    final MontyPlatformFactory? montyPlatformFactory =
+        wasmMode ? null : () async => MontyFfi(bindings: NativeBindingsFfi());
     extensionFactory = () async {
       final factory = createMontyScriptEnvironmentFactory(
         hostApi: hostApi,
         agentApi: agentApi,
         blackboardApi: blackboardApi,
         httpClient: fetchClient,
+        platformFactory: montyPlatformFactory,
         limits: MontyLimitsDefaults.tool,
       );
       final env = await factory();
@@ -384,11 +388,7 @@ Future<void> _dispatch({
   await _sendAndWait(ctx, ctx.defaultRoom, input);
 }
 
-Future<void> _sendAndWait(
-  _CliContext ctx,
-  String room,
-  String prompt,
-) async {
+Future<void> _sendAndWait(_CliContext ctx, String room, String prompt) async {
   final existingThread = ctx.threadFor(room);
   final label = existingThread != null
       ? 'Continuing thread ${_short(existingThread)}...'
@@ -406,9 +406,7 @@ Future<void> _sendAndWait(
     StreamSubscription<RunState>? traceSub;
     void Function()? eventUnsub;
     if (ctx.verbose) {
-      traceSub = session.stateChanges.listen(
-        _traceState,
-      );
+      traceSub = session.stateChanges.listen(_traceState);
       eventUnsub = session.lastExecutionEvent.subscribe((event) {
         if (event == null) return;
         _traceExecutionEvent(event);
@@ -457,10 +455,7 @@ Future<void> _sendToRoom(_CliContext ctx, String input) async {
   await _sendAndWait(ctx, targetRoom, prompt);
 }
 
-Future<void> _waitAll(
-  AgentRuntime runtime,
-  List<AgentSession> tracked,
-) async {
+Future<void> _waitAll(AgentRuntime runtime, List<AgentSession> tracked) async {
   if (tracked.isEmpty) {
     stdout.writeln('No tracked sessions.');
     return;
@@ -480,10 +475,7 @@ Future<void> _waitAll(
   tracked.clear();
 }
 
-Future<void> _waitAny(
-  AgentRuntime runtime,
-  List<AgentSession> tracked,
-) async {
+Future<void> _waitAny(AgentRuntime runtime, List<AgentSession> tracked) async {
   if (tracked.isEmpty) {
     stdout.writeln('No tracked sessions.');
     return;
@@ -495,9 +487,7 @@ Future<void> _waitAny(
       timeout: const Duration(seconds: 120),
     );
     stdout.writeln(formatResult(result));
-    tracked.removeWhere(
-      (s) => s.threadKey == result.threadKey,
-    );
+    tracked.removeWhere((s) => s.threadKey == result.threadKey);
     stdout.writeln('${tracked.length} session(s) remaining.');
   } on Object catch (e) {
     stdout.writeln('Error: $e');
@@ -604,9 +594,7 @@ void _traceState(RunState state) {
 void _traceExecutionEvent(ExecutionEvent event) {
   switch (event) {
     case ClientToolExecuting(:final toolName, :final toolCallId):
-      stderr.writeln(
-        '[TOOL] Executing $toolName  id=${_short(toolCallId)}',
-      );
+      stderr.writeln('[TOOL] Executing $toolName  id=${_short(toolCallId)}');
     case ClientToolCompleted(:final toolCallId, :final result, :final status):
       final preview =
           result.length > 200 ? '${result.substring(0, 200)}...' : result;

--- a/packages/soliplex_scripting/lib/src/monty_script_environment.dart
+++ b/packages/soliplex_scripting/lib/src/monty_script_environment.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
+    show MontyPlatform;
 import 'package:soliplex_agent/soliplex_agent.dart'
     show ClientTool, ScriptEnvironment;
 import 'package:soliplex_client/soliplex_client.dart' show ToolCallInfo;
@@ -26,15 +28,18 @@ class MontyScriptEnvironment implements ScriptEnvironment {
     required MontyBridge bridge,
     required DfRegistry dfRegistry,
     required StreamRegistry streamRegistry,
+    MontyPlatform? ownedPlatform,
     Duration executionTimeout = const Duration(seconds: 30),
     IsolatePlugin? isolatePlugin,
   })  : _bridge = bridge,
+        _ownedPlatform = ownedPlatform,
         _dfRegistry = dfRegistry,
         _streamRegistry = streamRegistry,
         _executionTimeout = executionTimeout,
         _isolatePlugin = isolatePlugin;
 
   final MontyBridge _bridge;
+  final MontyPlatform? _ownedPlatform;
   final DfRegistry _dfRegistry;
   final StreamRegistry _streamRegistry;
   final Duration _executionTimeout;
@@ -62,6 +67,7 @@ class MontyScriptEnvironment implements ScriptEnvironment {
     _disposed = true;
     if (_isolatePlugin != null) unawaited(_isolatePlugin.onDispose());
     _bridge.dispose();
+    if (_ownedPlatform != null) unawaited(_ownedPlatform.dispose());
     _dfRegistry.disposeAll();
     unawaited(_streamRegistry.dispose());
   }

--- a/packages/soliplex_scripting/lib/src/monty_script_environment_factory.dart
+++ b/packages/soliplex_scripting/lib/src/monty_script_environment_factory.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
+
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
-    show MontyLimits;
+    show MontyLimits, MontyPlatform;
 import 'package:soliplex_agent/soliplex_agent.dart'
     show AgentApi, BlackboardApi, FormApi, HostApi, ScriptEnvironmentFactory;
 import 'package:soliplex_client/soliplex_client.dart' show SoliplexHttpClient;
@@ -9,6 +11,9 @@ import 'package:soliplex_scripting/src/host_function_wiring.dart';
 import 'package:soliplex_scripting/src/monty_script_environment.dart';
 import 'package:soliplex_scripting/src/stream_registry.dart';
 
+/// Factory that creates a fresh [MontyPlatform] for each session.
+typedef MontyPlatformFactory = Future<MontyPlatform> Function();
+
 /// Creates a [ScriptEnvironmentFactory] that produces session-scoped
 /// [MontyScriptEnvironment] instances.
 ///
@@ -16,10 +21,16 @@ import 'package:soliplex_scripting/src/stream_registry.dart';
 /// registers host functions once, and returns an environment that
 /// disposes everything when the owning session dies.
 ///
+/// When [platformFactory] is provided, each session gets its own
+/// [MontyPlatform] instance, enabling concurrent Monty execution
+/// across sessions (e.g. parent + child agents). Without it, the
+/// bridge falls back to the global [MontyPlatform.instance] singleton.
+///
 /// ```dart
 /// final factory = createMontyScriptEnvironmentFactory(
 ///   hostApi: myHostApi,
 ///   agentApi: myAgentApi,
+///   platformFactory: () async => MontyFfi(bindings: NativeBindingsFfi()),
 /// );
 /// final runtime = AgentRuntime(
 ///   // ...
@@ -41,7 +52,9 @@ ScriptEnvironmentFactory createMontyScriptEnvironmentFactory({
   return () async {
     final dfRegistry = DfRegistry();
     final streamRegistry = StreamRegistry();
+    final platform = platformFactory != null ? await platformFactory() : null;
     final bridge = DefaultMontyBridge(
+      platform: platform,
       useFutures: false,
       limits: limits ?? MontyLimitsDefaults.tool,
     );
@@ -53,19 +66,26 @@ ScriptEnvironmentFactory createMontyScriptEnvironmentFactory({
       isolatePlugin.functions.forEach(bridge.register);
     }
 
-    HostFunctionWiring(
-      hostApi: hostApi,
-      agentApi: agentApi,
-      blackboardApi: blackboardApi,
-      httpClient: httpClient,
-      getAuthToken: getAuthToken,
-      dfRegistry: dfRegistry,
-      streamRegistry: streamRegistry,
-      formApi: formApi,
-      extraFunctions: extraFunctions,
-    ).registerOnto(bridge);
+    try {
+      HostFunctionWiring(
+        hostApi: hostApi,
+        agentApi: agentApi,
+        blackboardApi: blackboardApi,
+        httpClient: httpClient,
+        getAuthToken: getAuthToken,
+        dfRegistry: dfRegistry,
+        streamRegistry: streamRegistry,
+        formApi: formApi,
+        extraFunctions: extraFunctions,
+      ).registerOnto(bridge);
+    } on Object {
+      bridge.dispose();
+      if (platform != null) unawaited(platform.dispose());
+      rethrow;
+    }
     return MontyScriptEnvironment(
       bridge: bridge,
+      ownedPlatform: platform,
       dfRegistry: dfRegistry,
       streamRegistry: streamRegistry,
       executionTimeout: executionTimeout,


### PR DESCRIPTION
## Summary
- Each Monty session now gets its own `MontyPlatform` (FFI instance) via `MontyPlatformFactory`, eliminating the shared global singleton that caused `StateError: Cannot call start() while execution is active` when parent + child sessions ran concurrently
- Factory is optional — `null` falls back to `MontyPlatform.instance` (preserves WASM single-bridge constraint)
- `MontyScriptEnvironment` now owns and disposes its platform on teardown

## Changes
- **soliplex_scripting**: Add `MontyPlatformFactory` typedef and `platformFactory` param to `createMontyScriptEnvironmentFactory`. Each invocation creates a fresh platform, passes it to `DefaultMontyBridge(platform:)`, and transfers ownership to `MontyScriptEnvironment`. Guard against platform leak if host function registration fails.
- **soliplex_cli**: Pass `platformFactory` for native mode. Retain global singleton for `--wasm-mode` simulation.

## Context
When the 120b model generates Monty code that calls `spawn_agent()`, the child session creates its own `DefaultMontyBridge` but previously shared the global `MontyPlatform.instance` FFI singleton. Concurrent `start()`/`resume()` calls on the same C interpreter handle corrupted state. This blocked hierarchical supervision (L3 architecture).

Plan: `/Users/runyaga/dev/soliplex-plans/ffi-reentracy-bug-plan-2026-03-06.md`

## Test plan
- [x] 119/119 `soliplex_scripting` tests pass
- [x] 119/119 `soliplex_cli` tests pass (symlinked suite)
- [x] `dart analyze --fatal-infos` zero issues in both packages
- [x] Gemini 3.1-pro code review (WASM compat fix, leak guard added)
- [ ] Integration test: spawn_agent from Monty with concurrent FFI (Phase 3)
- [ ] Re-run experiment patterns 19-30 against live backend