### PR TITLE
feat(ci): scheduled LLM documentation audit

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -1,0 +1,53 @@
+name: Documentation Audit
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Every Monday 9am UTC
+  workflow_dispatch:  # Manual trigger for testing
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        run: pip install openai
+
+      - name: "Stage 1: Deterministic assertions"
+        run: |
+          chmod +x scripts/doc-audit-deterministic.sh
+          scripts/doc-audit-deterministic.sh . > report.json
+          echo "### Stage 1 Summary" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '"- Pass: \(.summary.pass)\n- Fail: \(.summary.fail)\n- Stale: \(.summary.stale_freshness)\n- Broken links: \(.summary.broken_links)"' report.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Stage 2: LLM evaluation"
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          chmod +x scripts/doc-audit-llm.py
+          python3 scripts/doc-audit-llm.py report.json . > findings.json
+          echo "### Stage 2 Summary" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '"- Total evaluated: \(.summary.total)\n- Pass: \(.summary.pass)\n- Fail: \(.summary.fail)"' findings.json >> "$GITHUB_STEP_SUMMARY"
+
+      - name: "Stage 3: File issues for failures"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/doc-audit-file-issues.sh
+          scripts/doc-audit-file-issues.sh findings.json
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doc-audit-report-${{ github.run_number }}
+          path: |
+            report.json
+            findings.json
+          retention-days: 90

--- a/scripts/doc-audit-deterministic.sh
+++ b/scripts/doc-audit-deterministic.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Deterministic documentation audit — Stage 1 (no LLM required)
+# Runs assertions from MAINTENANCE.md and outputs structured JSON report.
+set -euo pipefail
+
+REPO_ROOT="${1:-.}"
+TMPDIR_AUDIT=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_AUDIT"' EXIT
+
+# Use temp files so subshells can contribute findings
+ASSERTIONS_FILE="$TMPDIR_AUDIT/assertions.jsonl"
+BROKEN_FILE="$TMPDIR_AUDIT/broken.jsonl"
+FRESHNESS_FILE="$TMPDIR_AUDIT/freshness.jsonl"
+touch "$ASSERTIONS_FILE" "$BROKEN_FILE" "$FRESHNESS_FILE"
+
+add_assertion() {
+  local id="$1" name="$2" status="$3" detail="$4"
+  printf '{"id":"%s","name":"%s","status":"%s","detail":"%s"}\n' \
+    "$id" "$name" "$status" "$detail" >> "$ASSERTIONS_FILE"
+}
+
+echo "=== Doc Audit: Deterministic Stage ===" >&2
+
+# ---------------------------------------------------------------------------
+# A1: Public API Exports
+# ---------------------------------------------------------------------------
+echo "[A1] Checking soliplex_agent exports..." >&2
+BARREL="$REPO_ROOT/packages/soliplex_agent/lib/soliplex_agent.dart"
+if [ -f "$BARREL" ]; then
+  EXPORT_COUNT=$(grep -c "^export" "$BARREL" || true)
+  add_assertion "A1" "Public API exports exist" "pass" "$EXPORT_COUNT export statements found"
+else
+  add_assertion "A1" "Public API exports exist" "fail" "Barrel file not found"
+fi
+
+# ---------------------------------------------------------------------------
+# A2: HostApi package contract — no visual-domain methods beyond grandfathered
+# ---------------------------------------------------------------------------
+echo "[A2] Checking HostApi package contract..." >&2
+HOST_API="$REPO_ROOT/packages/soliplex_agent/lib/src/host/host_api.dart"
+if [ -f "$HOST_API" ]; then
+  # Only check actual method/field declarations, not comments or doc strings
+  VIOLATIONS=$(grep -n 'chart\|widget\|form\|Chart\|Widget\|Form' "$HOST_API" \
+    | grep -vE '^\s*[0-9]+:\s*//' \
+    | grep -vE '//' \
+    | grep -v 'import ' \
+    | grep -v 'registerDataFrame\|registerChart\|getDataFrame\|updateChart\|chartId\|chartConfig' \
+    || true)
+  if [ -z "$VIOLATIONS" ]; then
+    add_assertion "A2" "HostApi package contract" "pass" "No visual-domain methods beyond grandfathered"
+  else
+    CLEAN_VIOLATIONS=$(echo "$VIOLATIONS" | tr '\n' ' ' | tr '"' "'")
+    add_assertion "A2" "HostApi package contract" "fail" "$CLEAN_VIOLATIONS"
+  fi
+else
+  add_assertion "A2" "HostApi package contract" "fail" "File not found"
+fi
+
+# ---------------------------------------------------------------------------
+# A3: Package READMEs exist
+# ---------------------------------------------------------------------------
+echo "[A3] Checking package READMEs..." >&2
+MISSING_READMES=""
+for pkg in "$REPO_ROOT"/packages/soliplex_*/; do
+  if [ ! -f "$pkg/README.md" ]; then
+    PKG_NAME=$(basename "$pkg")
+    MISSING_READMES="${MISSING_READMES}${PKG_NAME} "
+  fi
+done
+if [ -z "$MISSING_READMES" ]; then
+  add_assertion "A3" "Package READMEs exist" "pass" "All packages have READMEs"
+else
+  add_assertion "A3" "Package READMEs exist" "fail" "Missing: $MISSING_READMES"
+fi
+
+# ---------------------------------------------------------------------------
+# A4: No broken internal doc links
+# ---------------------------------------------------------------------------
+echo "[A4] Checking internal doc links..." >&2
+while IFS= read -r file; do
+  DIR=$(dirname "$file")
+  LINKS=$(grep -oE '\]\([^)]+\.md[^)]*\)' "$file" 2>/dev/null | \
+    sed 's/\](//;s/)$//;s/#.*//' || true)
+  if [ -n "$LINKS" ]; then
+    while IFS= read -r link; do
+      case "$link" in http*) continue ;; esac
+      case "$link" in ~*) continue ;; esac
+      case "$link" in path.md*) continue ;; esac
+      [ -z "$link" ] && continue
+      TARGET="$DIR/$link"
+      if [ ! -f "$TARGET" ]; then
+        printf '{"file":"%s","link":"%s"}\n' "$file" "$link" >> "$BROKEN_FILE"
+      fi
+    done <<< "$LINKS"
+  fi
+done < <(find "$REPO_ROOT/docs" -name "*.md" -not -path "*/archive/*")
+
+BROKEN_COUNT=$(wc -l < "$BROKEN_FILE" | tr -d ' ')
+if [ "$BROKEN_COUNT" -eq 0 ]; then
+  add_assertion "A4" "No broken internal doc links" "pass" "All links resolve"
+else
+  add_assertion "A4" "No broken internal doc links" "fail" "$BROKEN_COUNT broken links found"
+fi
+
+# ---------------------------------------------------------------------------
+# A6: Pure Dart contract — no Flutter imports in pure Dart packages
+# ---------------------------------------------------------------------------
+echo "[A6] Checking pure Dart contract..." >&2
+PURE_VIOLATIONS=""
+for pkg in soliplex_agent soliplex_client soliplex_logging soliplex_scripting soliplex_interpreter_monty; do
+  PKG_LIB="$REPO_ROOT/packages/$pkg/lib/"
+  if [ -d "$PKG_LIB" ]; then
+    FLUTTER_IMPORTS=$(grep -rl "import 'package:flutter" "$PKG_LIB" 2>/dev/null || true)
+    if [ -n "$FLUTTER_IMPORTS" ]; then
+      PURE_VIOLATIONS="${PURE_VIOLATIONS}${pkg} "
+    fi
+  fi
+done
+if [ -z "$PURE_VIOLATIONS" ]; then
+  add_assertion "A6" "Pure Dart contract" "pass" "No Flutter imports in pure Dart packages"
+else
+  add_assertion "A6" "Pure Dart contract" "fail" "Violations: $PURE_VIOLATIONS"
+fi
+
+# ---------------------------------------------------------------------------
+# Freshness markers
+# ---------------------------------------------------------------------------
+echo "[FRESHNESS] Scanning freshness markers..." >&2
+TODAY=$(date -u +%Y-%m-%d)
+while IFS= read -r file; do
+  MARKER=$(grep -o 'freshness: verified=[0-9-]*, by=[a-z]*, next-check=[0-9-]*' "$file" 2>/dev/null || true)
+  if [ -n "$MARKER" ]; then
+    VERIFIED=$(echo "$MARKER" | sed 's/.*verified=\([0-9-]*\).*/\1/')
+    NEXT_CHECK=$(echo "$MARKER" | sed 's/.*next-check=\([0-9-]*\).*/\1/')
+    if [[ "$TODAY" > "$NEXT_CHECK" ]]; then
+      STATUS="stale"
+    else
+      STATUS="current"
+    fi
+    printf '{"file":"%s","verified":"%s","next_check":"%s","status":"%s"}\n' \
+      "$file" "$VERIFIED" "$NEXT_CHECK" "$STATUS" >> "$FRESHNESS_FILE"
+  fi
+done < <(find "$REPO_ROOT/docs" -name "*.md" -not -path "*/archive/*")
+
+# ---------------------------------------------------------------------------
+# Assemble final JSON report
+# ---------------------------------------------------------------------------
+ASSERTIONS=$(jq -s '.' "$ASSERTIONS_FILE")
+BROKEN=$(jq -s '.' "$BROKEN_FILE")
+FRESHNESS=$(jq -s '.' "$FRESHNESS_FILE")
+
+PASS_COUNT=$(echo "$ASSERTIONS" | jq '[.[] | select(.status=="pass")] | length')
+FAIL_COUNT=$(echo "$ASSERTIONS" | jq '[.[] | select(.status=="fail")] | length')
+STALE_COUNT=$(echo "$FRESHNESS" | jq '[.[] | select(.status=="stale")] | length')
+
+jq -n \
+  --argjson assertions "$ASSERTIONS" \
+  --argjson broken_links "$BROKEN" \
+  --argjson freshness "$FRESHNESS" \
+  --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson pass "$PASS_COUNT" \
+  --argjson fail "$FAIL_COUNT" \
+  --argjson stale "$STALE_COUNT" \
+  --argjson broken_count "$BROKEN_COUNT" \
+  '{
+    assertions: $assertions,
+    broken_links: $broken_links,
+    freshness: $freshness,
+    timestamp: $timestamp,
+    summary: {
+      pass: $pass,
+      fail: $fail,
+      stale_freshness: $stale,
+      broken_links: $broken_count
+    }
+  }'
+
+echo "" >&2
+echo "=== Summary: $PASS_COUNT pass, $FAIL_COUNT fail, $STALE_COUNT stale, $BROKEN_COUNT broken links ===" >&2

--- a/scripts/doc-audit-file-issues.sh
+++ b/scripts/doc-audit-file-issues.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Stage 3: File GitHub issues for audit findings.
+# Reads the LLM findings JSON and creates one issue per FAIL verdict.
+# Capped at 10 issues per run to prevent flooding.
+set -euo pipefail
+
+FINDINGS_FILE="${1:?Usage: $0 <findings.json>}"
+MAX_ISSUES="${2:-10}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [ ! -f "$FINDINGS_FILE" ]; then
+  echo "ERROR: Findings file not found: $FINDINGS_FILE" >&2
+  exit 1
+fi
+
+FAIL_COUNT=$(jq '[.findings[] | select(.verdict=="FAIL")] | length' "$FINDINGS_FILE")
+echo "Found $FAIL_COUNT FAIL verdicts in audit findings" >&2
+
+if [ "$FAIL_COUNT" -eq 0 ]; then
+  echo "No failures found. No issues to file." >&2
+  exit 0
+fi
+
+FILED=0
+
+jq -c '.findings[] | select(.verdict=="FAIL")' "$FINDINGS_FILE" | while IFS= read -r finding; do
+  if [ "$FILED" -ge "$MAX_ISSUES" ]; then
+    echo "Issue cap reached ($MAX_ISSUES). Remaining findings skipped." >&2
+    REMAINING=$((FAIL_COUNT - FILED))
+    echo "  $REMAINING additional failures not filed." >&2
+    break
+  fi
+
+  FILE=$(echo "$finding" | jq -r '.file')
+  SCORE=$(echo "$finding" | jq -r '.score // "unknown"')
+  CONCERNS=$(echo "$finding" | jq -r '.concerns | join("\n- ")')
+  EVIDENCE=$(echo "$finding" | jq -r '.evidence // "No raw evidence provided"')
+  SUGGESTED_FIX=$(echo "$finding" | jq -r '.suggested_fix // "No suggestion provided"')
+
+  TITLE="docs(audit): $FILE — $SCORE"
+  BODY="$(cat <<ISSUE
+## Documentation Audit Finding
+
+**File:** \`$FILE\`
+**Score:** $SCORE
+**Audit date:** $(date -u +%Y-%m-%d)
+**Source:** Automated LLM audit (doc-audit.yml)
+
+### Concerns
+
+- $CONCERNS
+
+### Evidence
+
+\`\`\`
+$EVIDENCE
+\`\`\`
+
+### Suggested fix
+
+$SUGGESTED_FIX
+
+---
+*Filed automatically by the documentation audit workflow.
+See MAINTENANCE.md for the evaluation criteria.*
+ISSUE
+)"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "=== DRY RUN: Would create issue ===" >&2
+    echo "Title: $TITLE" >&2
+    echo "---" >&2
+    echo "$BODY" >&2
+    echo "===" >&2
+  else
+    echo "Filing issue for $FILE..." >&2
+    gh issue create \
+      --title "$TITLE" \
+      --label "documentation" \
+      --body "$BODY" 2>&1 || echo "WARNING: Failed to create issue for $FILE" >&2
+  fi
+
+  FILED=$((FILED + 1))
+done
+
+echo "Done. Filed $FILED issues." >&2

--- a/scripts/doc-audit-llm.py
+++ b/scripts/doc-audit-llm.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Stage 2: LLM-powered documentation evaluation.
+
+Reads the deterministic report from Stage 1 and each doc file, sends them
+to OpenAI for evaluation against the readiness gate criteria from
+MAINTENANCE.md, and outputs structured findings as JSON.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+try:
+    from openai import OpenAI
+except ImportError:
+    print("ERROR: openai package not installed. Run: pip install openai", file=sys.stderr)
+    sys.exit(1)
+
+SYSTEM_PROMPT = """\
+You are a documentation auditor for the Soliplex Flutter monorepo. Your job is
+to evaluate documentation against the maintenance protocol's readiness gate.
+
+## Governing Principle: Fail by Default
+
+All documentation is assumed stale until proven current. The burden of proof is
+on the document, not the reviewer. No effort = fail. Evidence required.
+
+## Your Evaluation Process
+
+For each document you are given:
+1. Check if the deterministic assertions relevant to it passed or failed
+2. Evaluate the document content against these criteria:
+   - Are factual claims verifiable by running a command or reading source?
+   - Do code examples look correct (classes/methods exist, signatures match)?
+   - Is the content consistent with other docs and the assertion report?
+   - Are there signs of staleness (references to deleted code, old patterns)?
+3. Produce a verdict: PASS or FAIL
+4. For FAIL: describe exactly what is wrong with specific evidence
+
+## Anti-Sycophancy Rules (MANDATORY)
+
+- You MUST attempt to FALSIFY each document, not confirm it
+- You MUST report at least one concern or gap per document, even if minor
+- If you genuinely find zero issues, state: "I found no issues. This is
+  unusual — a human should double-check."
+- "Looks good" or "appears complete" is NOT evidence
+- "I could not find a counterexample" is NOT evidence of correctness
+
+## Output Format
+
+Return a JSON array of findings. Each finding is an object:
+{
+  "file": "path/to/doc.md",
+  "verdict": "PASS" or "FAIL",
+  "score": "N/6",
+  "concerns": ["specific concern 1", "specific concern 2"],
+  "evidence": "raw evidence supporting concerns",
+  "suggested_fix": "concrete action to resolve (for FAIL only)"
+}
+
+Return ONLY the JSON array, no markdown fences, no preamble.
+"""
+
+
+def load_report(report_path: str) -> dict:
+    with open(report_path) as f:
+        return json.load(f)
+
+
+def collect_docs(repo_root: str) -> list[tuple[str, str]]:
+    """Collect all non-archived markdown docs with their content."""
+    docs_dir = Path(repo_root) / "docs"
+    docs = []
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        if "archive" in md_file.parts:
+            continue
+        rel_path = str(md_file.relative_to(repo_root))
+        try:
+            content = md_file.read_text(encoding="utf-8")
+            # Skip very large files (> 50KB) to stay within token limits
+            if len(content) > 50_000:
+                content = content[:50_000] + "\n\n[TRUNCATED — file exceeds 50KB]"
+            docs.append((rel_path, content))
+        except Exception as e:
+            print(f"WARNING: Could not read {md_file}: {e}", file=sys.stderr)
+    return docs
+
+
+def build_user_prompt(report: dict, docs: list[tuple[str, str]]) -> str:
+    """Build the user prompt with the deterministic report and doc contents."""
+    parts = [
+        "## Deterministic Audit Report (Stage 1)\n",
+        "```json",
+        json.dumps(report, indent=2),
+        "```\n",
+        f"## Documents to Evaluate ({len(docs)} files)\n",
+    ]
+    for path, content in docs:
+        parts.append(f"### {path}\n")
+        parts.append(f"```markdown\n{content}\n```\n")
+
+    return "\n".join(parts)
+
+
+def run_evaluation(report: dict, docs: list[tuple[str, str]]) -> list[dict]:
+    """Send docs to OpenAI for evaluation."""
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print("ERROR: OPENAI_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    client = OpenAI(api_key=api_key)
+    user_prompt = build_user_prompt(report, docs)
+
+    # Estimate tokens — bail if too large
+    estimated_chars = len(SYSTEM_PROMPT) + len(user_prompt)
+    if estimated_chars > 500_000:
+        print(
+            f"WARNING: Input is ~{estimated_chars // 1000}K chars. "
+            "Splitting into batches.",
+            file=sys.stderr,
+        )
+        return run_batched_evaluation(client, report, docs)
+
+    print(f"Sending {len(docs)} docs to OpenAI for evaluation...", file=sys.stderr)
+
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        temperature=0.1,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+    )
+
+    content = response.choices[0].message.content
+    try:
+        result = json.loads(content)
+        # Handle both {"findings": [...]} and bare [...]
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict) and "findings" in result:
+            return result["findings"]
+        return [result]
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Failed to parse LLM response as JSON: {e}", file=sys.stderr)
+        print(f"Raw response: {content[:500]}", file=sys.stderr)
+        sys.exit(1)
+
+
+def run_batched_evaluation(
+    client: OpenAI, report: dict, docs: list[tuple[str, str]]
+) -> list[dict]:
+    """Split docs into batches and evaluate each separately."""
+    BATCH_SIZE = 5
+    all_findings = []
+
+    for i in range(0, len(docs), BATCH_SIZE):
+        batch = docs[i : i + BATCH_SIZE]
+        batch_num = (i // BATCH_SIZE) + 1
+        total_batches = (len(docs) + BATCH_SIZE - 1) // BATCH_SIZE
+        print(
+            f"  Batch {batch_num}/{total_batches}: {len(batch)} docs...",
+            file=sys.stderr,
+        )
+
+        user_prompt = build_user_prompt(report, batch)
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            temperature=0.1,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+        content = response.choices[0].message.content
+        try:
+            result = json.loads(content)
+            if isinstance(result, list):
+                all_findings.extend(result)
+            elif isinstance(result, dict) and "findings" in result:
+                all_findings.extend(result["findings"])
+            else:
+                all_findings.append(result)
+        except json.JSONDecodeError as e:
+            print(
+                f"WARNING: Batch {batch_num} response not valid JSON: {e}",
+                file=sys.stderr,
+            )
+
+    return all_findings
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <report.json> [repo_root]", file=sys.stderr)
+        sys.exit(1)
+
+    report_path = sys.argv[1]
+    repo_root = sys.argv[2] if len(sys.argv) > 2 else "."
+
+    report = load_report(report_path)
+    docs = collect_docs(repo_root)
+    print(f"Collected {len(docs)} docs for evaluation", file=sys.stderr)
+
+    findings = run_evaluation(report, docs)
+
+    # Add summary stats
+    fail_count = sum(1 for f in findings if f.get("verdict") == "FAIL")
+    pass_count = sum(1 for f in findings if f.get("verdict") == "PASS")
+
+    output = {
+        "findings": findings,
+        "summary": {
+            "total": len(findings),
+            "pass": pass_count,
+            "fail": fail_count,
+        },
+    }
+
+    print(json.dumps(output, indent=2))
+    print(
+        f"\nEvaluation complete: {pass_count} pass, {fail_count} fail",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Three-stage documentation audit pipeline (deterministic + LLM + issue filing)
- Runs weekly via cron, manual trigger supported
- Deterministic assertions tested locally: finds real issues

## Changes

- **scripts/doc-audit-deterministic.sh**: Runs assertions A1-A6 from MAINTENANCE.md, outputs structured JSON. No LLM needed.
- **scripts/doc-audit-llm.py**: Sends docs + assertion report to OpenAI (gpt-4o), enforces fail-by-default doctrine and anti-sycophancy rules, returns structured PASS/FAIL verdicts
- **scripts/doc-audit-file-issues.sh**: Creates GitHub issues from FAIL findings, capped at 10 per run
- **.github/workflows/doc-audit.yml**: Weekly cron (Monday 9am UTC) + manual dispatch. Uploads audit report as artifact.

## Prerequisites

- `OPENAI_API_KEY` repo secret (already added, budget locked)

## Test plan

- [x] `doc-audit-deterministic.sh` runs locally: 3 pass, 2 fail (real findings)
- [x] Scripts are executable (chmod +x)
- [x] Pre-commit hooks pass
- [ ] Manual workflow_dispatch after merge to validate full pipeline