### PR TITLE
refactor(deps): port all packages to dart_monty git main

### DIFF
--- a/packages/soliplex_cli/CLAUDE.md
+++ b/packages/soliplex_cli/CLAUDE.md
@@ -13,6 +13,12 @@ dart run bin/soliplex_cli.dart
 dart run bin/soliplex_cli.dart --host http://localhost:8000 --room plain
 dart run bin/soliplex_cli.dart --monty --room spike-20b
 dart run bin/soliplex_cli.dart --monty --wasm-mode --room spike-20b
+
+# Multiple prompts run sequentially in the same thread (shared state):
+dart run bin/soliplex_cli.dart --monty --room spike-20b \
+  -p "Write a function to add two numbers" \
+  -p "Now call add(3, 4) and print the result" \
+  -p "What functions have we defined so far?"
 ```
 
 ## Architecture

--- a/packages/soliplex_cli/pubspec.yaml
+++ b/packages/soliplex_cli/pubspec.yaml
@@ -8,8 +8,16 @@ environment:
 
 dependencies:
   args: ^2.4.0
-  dart_monty_ffi: ^0.6.1
-  dart_monty_platform_interface: ^0.6.1
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
   soliplex_agent:
     path: ../soliplex_agent
   soliplex_client:
@@ -27,4 +35,11 @@ dev_dependencies:
   mocktail: ^1.0.0
   test: ^1.24.0
   very_good_analysis: ^10.0.0
+
+dependency_overrides:
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
 

--- a/packages/soliplex_interpreter_monty/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/bridge/default_monty_bridge.dart
@@ -151,6 +151,10 @@ class DefaultMontyBridge implements MontyBridge {
             return;
         }
       }
+    } on MontyCancelledError {
+      controller.add(const BridgeRunError(message: 'Execution cancelled'));
+    } on MontyError catch (e) {
+      controller.add(BridgeRunError(message: e.message));
     } on MontyException catch (e) {
       controller.add(BridgeRunError(message: e.message));
     } on Object catch (e) {
@@ -269,7 +273,19 @@ class DefaultMontyBridge implements MontyBridge {
     // Launch handler and store future for later resolution.
     // Errors are caught during resolution in _resolveFutures; suppress
     // unhandled async error reporting in the meantime.
-    final handlerFuture = fn.handler(args);
+    //
+    // If the handler throws synchronously (before returning a Future),
+    // we must catch it here to avoid deadlocking the platform in active
+    // state with a leaked FFI handle.
+    final Future<Object?> handlerFuture;
+    try {
+      handlerFuture = fn.handler(args);
+    } on Object catch (e) {
+      controller
+        ..add(BridgeToolCallResult(callId: callId, result: 'Error: $e'))
+        ..add(BridgeStepFinished(stepId: stepName));
+      return _platform.resumeWithError(e.toString());
+    }
     unawaited(handlerFuture.then<void>((_) {}, onError: (_, __) {}));
     _pendingFutures[pending.callId] = _PendingFuture(
       future: handlerFuture,

--- a/packages/soliplex_interpreter_monty/lib/src/monty_execution_service.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/monty_execution_service.dart
@@ -120,6 +120,11 @@ class MontyExecutionService {
             return;
         }
       }
+    } on MontyCancelledError {
+      // Supervisor-initiated cancel — not a script error.
+      return;
+    } on MontyError catch (e) {
+      controller.addError(e);
     } on MontyException catch (e) {
       controller.add(ConsoleError(e));
     } on Exception catch (e) {

--- a/packages/soliplex_interpreter_monty/lib/src/plugins/isolate_plugin.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/plugins/isolate_plugin.dart
@@ -23,6 +23,7 @@ class _ChildHandle {
   Future<void> cancel() async {
     isAlive = false;
     await subscription?.cancel();
+    await platform.cancel();
     bridge.dispose();
     await platform.dispose();
   }

--- a/packages/soliplex_interpreter_monty/lib/src/schema_executor.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/schema_executor.dart
@@ -1,5 +1,29 @@
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 
+/// Converts a Dart value to a Python literal string.
+String _toPythonLiteral(Object? value) {
+  if (value == null) return 'None';
+  if (value is bool) return value ? 'True' : 'False';
+  if (value is num) return value.toString();
+  if (value is String) {
+    final escaped = value
+        .replaceAll(r'\', r'\\')
+        .replaceAll("'", r"\'")
+        .replaceAll('\n', r'\n');
+    return "'$escaped'";
+  }
+  if (value is List) {
+    return '[${value.map(_toPythonLiteral).join(', ')}]';
+  }
+  if (value is Map) {
+    final entries = value.entries
+        .map((e) => '${_toPythonLiteral(e.key)}: ${_toPythonLiteral(e.value)}')
+        .join(', ');
+    return '{$entries}';
+  }
+  return "'$value'";
+}
+
 /// Executes Monty-compatible Python schema validators at runtime.
 ///
 /// Fetched Python code (generated from backend Pydantic models) is cached
@@ -48,9 +72,10 @@ class SchemaExecutor {
       throw ArgumentError.value(schemaName, 'schemaName', 'Unknown schema');
     }
 
-    final code = 'raw = __input__\n$schemaCode\nvalidate_$schemaName(raw)';
+    final literal = _toPythonLiteral(rawJson);
+    final code = 'raw = $literal\n$schemaCode\nvalidate_$schemaName(raw)';
 
-    final result = await _platform.run(code, inputs: {'__input__': rawJson});
+    final result = await _platform.run(code);
 
     if (result.isError) {
       throw result.error!;

--- a/packages/soliplex_interpreter_monty/pubspec.yaml
+++ b/packages/soliplex_interpreter_monty/pubspec.yaml
@@ -7,7 +7,11 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  dart_monty_platform_interface: ^0.6.1
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
   meta: ^1.11.0
 
 dev_dependencies:

--- a/packages/soliplex_interpreter_monty/test/integration/layer1_introspection_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer1_introspection_test.dart
@@ -14,7 +14,7 @@ void main() {
       late DefaultMontyBridge bridge;
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
         (HostFunctionRegistry()
               ..addCategory('finance', [
                 HostFunction(

--- a/packages/soliplex_interpreter_monty/test/integration/layer1_tool_calls_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer1_tool_calls_test.dart
@@ -15,7 +15,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -79,7 +79,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -167,7 +167,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -230,7 +230,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -307,7 +307,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -356,7 +356,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());
@@ -407,7 +407,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
       });
 
       tearDown(() => bridge.dispose());

--- a/packages/soliplex_interpreter_monty/test/integration/layer2_agentic_pipeline_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer2_agentic_pipeline_test.dart
@@ -15,7 +15,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
 
         (HostFunctionRegistry()
               ..addCategory('research', [
@@ -120,7 +120,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
 
         (HostFunctionRegistry()
               ..addCategory('data', [
@@ -227,7 +227,7 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
 
         (HostFunctionRegistry()
               ..addCategory('storage', [

--- a/packages/soliplex_interpreter_monty/test/integration/room_fixture.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/room_fixture.dart
@@ -85,7 +85,7 @@ BridgeToolCallResult? findToolCallResult(
 /// executes code, and returns collected events.
 Future<List<BridgeEvent>> runRoom(RoomFixture room) async {
   final mock = buildMockPlatform(room.progressQueue);
-  final bridge = DefaultMontyBridge(platform: mock);
+  final bridge = DefaultMontyBridge(platform: mock, useFutures: false);
 
   room.functions.forEach(bridge.register);
 

--- a/packages/soliplex_interpreter_monty/test/src/schema_executor_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/schema_executor_test.dart
@@ -82,12 +82,12 @@ void main() {
 
       await executor.validate('tool', <String, Object?>{});
 
-      expect(mock.lastRunCode, contains('raw = __input__'));
+      expect(mock.lastRunCode, contains('raw = {}'));
       expect(mock.lastRunCode, contains('def validate_tool(raw):'));
       expect(mock.lastRunCode, contains('validate_tool(raw)'));
     });
 
-    test('passes raw JSON as __input__', () async {
+    test('inlines raw JSON as Python literal', () async {
       executor.loadSchemas({'tool': _toolValidatorCode});
 
       mock.runResult = const MontyResult(
@@ -95,10 +95,9 @@ void main() {
         usage: _usage,
       );
 
-      final input = <String, Object?>{'kind': 'test'};
-      await executor.validate('tool', input);
+      await executor.validate('tool', <String, Object?>{'kind': 'test'});
 
-      expect(mock.lastRunInputs, containsPair('__input__', input));
+      expect(mock.lastRunCode, contains("raw = {'kind': 'test'}"));
     });
 
     test('throws ArgumentError for unknown schema', () async {

--- a/packages/soliplex_interpreter_monty/test/src/schema_spike_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/schema_spike_test.dart
@@ -51,20 +51,7 @@ $_validateToolPython
 validate_tool(raw)
 ''';
 
-      final result = await mock.run(
-        code,
-        inputs: {
-          '__input__': {
-            'kind': 'search',
-            'tool_name': 'tools.search',
-            'tool_description': 'Search indexed documents',
-            'tool_requires': 'bare',
-            'allow_mcp': false,
-            'agui_feature_names': ['code_execution'],
-            'extra_parameters': <String, Object?>{},
-          },
-        },
-      );
+      final result = await mock.run(code);
 
       expect(result.error, isNull);
 
@@ -98,14 +85,10 @@ $_validateToolPython
 validate_tool(raw)
 ''';
 
-      await mock.run(code, inputs: {'__input__': <String, Object?>{}});
+      await mock.run(code);
 
       expect(mock.lastRunCode, contains('def validate_tool(raw):'));
       expect(mock.lastRunCode, contains('validate_tool(raw)'));
-      expect(
-        mock.lastRunInputs,
-        containsPair('__input__', isA<Map<String, Object?>>()),
-      );
     });
 
     test('handles missing fields with defaults', () async {
@@ -129,10 +112,7 @@ $_validateToolPython
 validate_tool(raw)
 ''';
 
-      final result = await mock.run(
-        code,
-        inputs: {'__input__': <String, Object?>{}},
-      );
+      final result = await mock.run(code);
 
       expect(result.error, isNull);
 
@@ -164,17 +144,7 @@ $_validateToolPython
 validate_tool(raw)
 ''';
 
-      final result = await mock.run(
-        code,
-        inputs: {
-          '__input__': {
-            'kind': 42, // int → str
-            'allow_mcp': 1, // int → bool
-            'agui_feature_names': ['a', 'b'],
-            'extra_parameters': {'key': 'val'},
-          },
-        },
-      );
+      final result = await mock.run(code);
 
       expect(result.error, isNull);
 

--- a/packages/soliplex_scripting/pubspec.yaml
+++ b/packages/soliplex_scripting/pubspec.yaml
@@ -11,7 +11,11 @@ dependencies:
     git:
       url: https://github.com/soliplex/ag-ui.git
       path: sdks/community/dart
-  dart_monty_platform_interface: ^0.6.1
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
   meta: ^1.11.0
   soliplex_agent:
     path: ../soliplex_agent

--- a/packages/soliplex_tui/pubspec.yaml
+++ b/packages/soliplex_tui/pubspec.yaml
@@ -8,8 +8,16 @@ environment:
 
 dependencies:
   args: ^2.5.0
-  dart_monty_ffi: ^0.6.1
-  dart_monty_platform_interface: ^0.6.1
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
   glob: ^2.1.0
   nocterm: ^0.5.0
   signals_core: ^6.2.0
@@ -30,4 +38,11 @@ dev_dependencies:
   mocktail: ^1.0.0
   test: ^1.25.0
   very_good_analysis: ^10.0.0
+
+dependency_overrides:
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -187,44 +187,49 @@ packages:
     source: hosted
     version: "1.0.8"
   dart_monty_ffi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: dart_monty_ffi
-      sha256: "9f0782a04be8994e53b6ca8f24a86adc1af682e2e030b8c05119a2140441d54f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "packages/dart_monty_ffi"
+      ref: main
+      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
+    version: "0.7.0"
   dart_monty_native:
     dependency: "direct main"
     description:
-      name: dart_monty_native
-      sha256: "410bad9e4b7cc4946f8ac37c8039b36bbc5092d6e89810f0caca00168b10b3cc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "packages/dart_monty_native"
+      ref: main
+      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
+    version: "0.7.0"
   dart_monty_platform_interface:
     dependency: "direct main"
     description:
-      name: dart_monty_platform_interface
-      sha256: "52a8524b26600161820f3f31df244fd9a9514ef832df1939e1e0d3a4b649ef8d"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/dart_monty_platform_interface"
+      ref: main
+      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
     version: "0.6.1"
   dart_monty_wasm:
     dependency: "direct main"
     description:
-      name: dart_monty_wasm
-      sha256: "4458b56a92b888772fa36ab332f5f24f80aeecb0029e3fedbda6c5c90c3a5878"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/dart_monty_wasm"
+      ref: main
+      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
     version: "0.6.1"
   dart_monty_web:
     dependency: "direct main"
     description:
-      name: dart_monty_web
-      sha256: "4a24c93b4227aca028330ee692126dd6060a2f09b4b00fdea14768ff71b94d2a"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/dart_monty_web"
+      ref: main
+      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
     version: "0.6.1"
   dbus:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,26 @@ environment:
 dependencies:
   connectivity_plus: ^7.0.0
   cupertino_icons: ^1.0.8
-  dart_monty_native: ^0.6.1
-  dart_monty_platform_interface: ^0.6.1
-  dart_monty_wasm: ^0.6.1
-  dart_monty_web: ^0.6.1
+  dart_monty_native:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_native
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  dart_monty_web:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_web
   device_info_plus: ^12.3.0
   fl_chart: ^0.70.2
   flutter:
@@ -59,6 +75,23 @@ dependencies:
       url: https://github.com/soliplex/wakelock_plus.git
       path: wakelock_plus
   web: ^1.1.1
+
+dependency_overrides:
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
 
 dev_dependencies:
   fake_async: ^1.3.3


### PR DESCRIPTION
## Summary
- Migrate all packages from pub.dev `dart_monty ^0.6.1` to git-based `dart_monty` main (PRs #99-#110)
- Picks up: sealed MontyError hierarchy, MontyCancelToken, `inputs` param removal, sync throw deadlock fix, monty fork migration
- Adds `dependency_overrides` where needed to resolve cross-package version solver conflicts

## Changes
- **soliplex_interpreter_monty**: MontyCancelledError/MontyError catch blocks, sync throw deadlock fix in `_dispatchToolCallAsFuture`, `_toPythonLiteral()` replaces removed `inputs` param in SchemaExecutor, `platform.cancel()` in isolate plugin
- **soliplex_scripting**: git dep for `dart_monty_platform_interface`
- **soliplex_cli**: git deps for `dart_monty_ffi` + `platform_interface`, dependency_overrides, multi-prompt howto in CLAUDE.md
- **soliplex_tui**: git deps for `dart_monty_ffi` + `platform_interface`, dependency_overrides
- **root pubspec.yaml**: git deps for native/platform_interface/wasm/web, dependency_overrides for platform_interface/wasm/ffi
- **Tests**: `useFutures: false` on integration test bridges (MockMontyPlatform now implements MontyFutureCapable), updated schema assertions

## Test plan
- [x] soliplex_interpreter_monty unit tests: 321/321
- [x] dart_monty_ffi integration: 138/140 (2 pre-existing)
- [x] Native Python ladder: 112/112
- [x] Web (WASM) Python ladder: 112/112
- [x] dart_monty_wasm unit tests: 65/65