### PR TITLE
fix(http): survive transient stream errors with inactivity timeout

### DIFF
--- a/packages/soliplex_client/lib/src/http/http_transport.dart
+++ b/packages/soliplex_client/lib/src/http/http_transport.dart
@@ -214,11 +214,13 @@ class HttpTransport {
   ) {
     late StreamController<List<int>> controller;
     StreamSubscription<List<int>>? subscription;
+    Timer? inactivityTimer;
 
     controller = StreamController<List<int>>(
       onListen: () {
         // Listen to cancellation
         cancelToken.whenCancelled.then((_) {
+          inactivityTimer?.cancel();
           if (!controller.isClosed) {
             controller
               ..addError(CancelledException(reason: cancelToken.reason))
@@ -227,16 +229,37 @@ class HttpTransport {
           }
         });
 
-        // Forward stream data
+        // Forward stream data with inactivity timeout on errors.
+        // Transient errors (e.g. Chrome ERR_NETWORK_CHANGED) are forwarded
+        // but don't kill the stream. If no data arrives within 30s after
+        // an error, the connection is considered dead and closed.
         subscription = source.listen(
-          controller.add,
-          onError: controller.addError,
-          onDone: controller.close,
+          (data) {
+            inactivityTimer?.cancel();
+            inactivityTimer = null;
+            controller.add(data);
+          },
+          onError: (Object error, StackTrace stackTrace) {
+            controller.addError(error, stackTrace);
+            inactivityTimer ??= Timer(const Duration(seconds: 30), () {
+              subscription?.cancel();
+              if (!controller.isClosed) {
+                controller.close();
+              }
+            });
+          },
+          onDone: () {
+            inactivityTimer?.cancel();
+            controller.close();
+          },
         );
       },
       onPause: () => subscription?.pause(),
       onResume: () => subscription?.resume(),
-      onCancel: () => subscription?.cancel(),
+      onCancel: () {
+        inactivityTimer?.cancel();
+        subscription?.cancel();
+      },
     );
 
     return controller.stream;
@@ -253,7 +276,8 @@ class HttpTransport {
       return;
     }
 
-    final message = 'HTTP $statusCode'
+    final message =
+        'HTTP $statusCode'
         '${response.reasonPhrase != null ? ': ${response.reasonPhrase}' : ''}';
 
     if (statusCode == 401 || statusCode == 403) {
@@ -336,7 +360,8 @@ class HttpTransport {
 
     // Check if response is JSON
     final contentType = response.contentType ?? '';
-    final isJson = contentType.contains('application/json') ||
+    final isJson =
+        contentType.contains('application/json') ||
         body.trimLeft().startsWith('{') ||
         body.trimLeft().startsWith('[');
 


### PR DESCRIPTION
## Summary
- Add 30-second inactivity timeout to `_wrapStreamWithCancellation` in `HttpTransport`
- Transient stream errors (Chrome `ERR_NETWORK_CHANGED`) no longer kill the SSE run
- Timer resets on data, cancels on done/cancel/CancelToken

## Problem
Chrome fires `net::ERR_NETWORK_CHANGED` on network interface changes (wifi hop, VPN reconnect). This kills the SSE stream mid-run. Observed in production: 5 successful runs, then 6th fails between `TOOL_END` and `TOOL_RESULT`.

Backport of soliplex/flutter#426, adapted for the fork's `Future<StreamedHttpResponse>` + `_wrapStreamWithCancellation` architecture. Upstream uses `cancelOnError: false` in `DartHttpClient`; here the fix goes into `HttpTransport` since that's where the `StreamController` wrapping lives.

## Changes
- **`packages/soliplex_client/lib/src/http/http_transport.dart`**: Inactivity timer in `_wrapStreamWithCancellation` — error starts 30s deadline, data resets it, done/cancel/CancelToken cancels it.

## Test plan
- [x] 1197/1197 unit tests pass
- [x] `dart analyze` clean
- [x] `dart format` clean