### PR TITLE
fix(completions,mcp): resolve analyzer warnings in integration tests

### DIFF
--- a/packages/soliplex_completions/test/src/ollama_llm_provider_integration_test.dart
+++ b/packages/soliplex_completions/test/src/ollama_llm_provider_integration_test.dart
@@ -1,4 +1,6 @@
 @Tags(['integration'])
+library;
+
 import 'package:soliplex_completions/soliplex_completions.dart';
 import 'package:test/test.dart';
 
@@ -27,73 +29,109 @@ void main() {
   });
 
   group('OllamaLlmProvider integration', () {
-    test('complete returns non-empty response', () async {
-      final result = await provider.complete(
-        'Reply with exactly one word: hello',
-        maxTokens: defaultMaxTokens,
-      );
+    test(
+      'complete returns non-empty response',
+      () async {
+        final result = await provider.complete(
+          'Reply with exactly one word: hello',
+          maxTokens: defaultMaxTokens,
+        );
 
-      expect(result, isNotEmpty, reason: 'Ollama returned empty content');
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        expect(result, isNotEmpty, reason: 'Ollama returned empty content');
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
 
-    test('complete with system prompt', () async {
-      final result = await provider.complete(
-        'What is 2 + 2?',
-        systemPrompt: 'You are a calculator. Reply with only the number.',
-        maxTokens: defaultMaxTokens,
-      );
+    test(
+      'complete with system prompt',
+      () async {
+        final result = await provider.complete(
+          'What is 2 + 2?',
+          systemPrompt: 'You are a calculator. Reply with only the number.',
+          maxTokens: defaultMaxTokens,
+        );
 
-      expect(result, isNotEmpty);
-      expect(result, contains('4'));
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        expect(result, isNotEmpty);
+        expect(result, contains('4'));
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
 
-    test('chat single turn', () async {
-      final result = await provider.chat(
-        [(role: 'user', content: 'Say "pong" and nothing else.')],
-        maxTokens: defaultMaxTokens,
-      );
+    test(
+      'chat single turn',
+      () async {
+        final result = await provider.chat(
+          [(role: 'user', content: 'Say "pong" and nothing else.')],
+          maxTokens: defaultMaxTokens,
+        );
 
-      expect(result, isNotEmpty);
-      expect(result.toLowerCase(), contains('pong'));
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        expect(result, isNotEmpty);
+        expect(result.toLowerCase(), contains('pong'));
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
 
-    test('chat multi-turn', () async {
-      final result = await provider.chat(
-        [
-          (role: 'user', content: 'Remember the number 42.'),
-          (role: 'assistant', content: 'I will remember 42.'),
-          (role: 'user', content: 'What number did I ask you to remember?'),
-        ],
-        systemPrompt: 'Reply with only the number, no explanation.',
-        maxTokens: defaultMaxTokens,
-      );
+    test(
+      'chat multi-turn',
+      () async {
+        final result = await provider.chat(
+          [
+            (role: 'user', content: 'Remember the number 42.'),
+            (role: 'assistant', content: 'I will remember 42.'),
+            (role: 'user', content: 'What number did I ask you to remember?'),
+          ],
+          systemPrompt: 'Reply with only the number, no explanation.',
+          maxTokens: defaultMaxTokens,
+        );
 
-      expect(result, isNotEmpty);
-      expect(result, contains('42'));
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        expect(result, isNotEmpty);
+        expect(result, contains('42'));
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
 
-    test('complete without maxTokens returns response', () async {
-      final result = await provider.complete('Say the word "test".');
+    test(
+      'complete without maxTokens returns response',
+      () async {
+        final result = await provider.complete('Say the word "test".');
 
-      expect(result, isNotEmpty);
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        expect(result, isNotEmpty);
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
 
-    test('LlmProvider contract — complete and chat return strings', () async {
-      final LlmProvider contract = provider;
+    test(
+      'LlmProvider contract — complete and chat return strings',
+      () async {
+        final LlmProvider contract = provider;
 
-      final completeResult = await contract.complete(
-        'Say hi',
-        maxTokens: defaultMaxTokens,
-      );
-      expect(completeResult, isA<String>());
-      expect(completeResult, isNotEmpty);
+        final completeResult = await contract.complete(
+          'Say hi',
+          maxTokens: defaultMaxTokens,
+        );
+        expect(completeResult, isA<String>());
+        expect(completeResult, isNotEmpty);
 
-      final chatResult = await contract.chat(
-        [(role: 'user', content: 'Say hi')],
-        maxTokens: defaultMaxTokens,
-      );
-      expect(chatResult, isA<String>());
-      expect(chatResult, isNotEmpty);
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        final chatResult = await contract.chat(
+          [(role: 'user', content: 'Say hi')],
+          maxTokens: defaultMaxTokens,
+        );
+        expect(chatResult, isA<String>());
+        expect(chatResult, isNotEmpty);
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
   });
 }

--- a/packages/soliplex_mcp/test/src/completions_mcp_integration_test.dart
+++ b/packages/soliplex_mcp/test/src/completions_mcp_integration_test.dart
@@ -1,4 +1,6 @@
 @Tags(['integration'])
+library;
+
 import 'dart:io';
 
 import 'package:soliplex_completions/soliplex_completions.dart';
@@ -17,7 +19,7 @@ import 'package:test/test.dart';
 ///
 /// Run:
 ///   cd packages/soliplex_mcp
-///   BRAVE_API_KEY=<key> dart test --tags=integration --run-skipped
+///   BRAVE_API_KEY=`<key>` dart test --tags=integration --run-skipped
 void main() {
   final apiKey = Platform.environment['BRAVE_API_KEY'];
 
@@ -33,7 +35,7 @@ void main() {
       serverConfigs: {
         'brave': McpServerConfig.stdio(
           command: 'npx',
-          args: ['-y', '@brave/brave-search-mcp-server'],
+          args: const ['-y', '@brave/brave-search-mcp-server'],
           environment: {
             ...Platform.environment,
             'BRAVE_API_KEY': apiKey,
@@ -50,54 +52,66 @@ void main() {
   });
 
   group('MCP + LLM end-to-end', () {
-    test('search via MCP, summarize via LLM', () async {
-      // Step 1: Use MCP to search
-      final searchResult = await mcp.executeTool(
-        'brave',
-        'brave_web_search',
-        {'query': 'Dart programming language features'},
-      );
+    test(
+      'search via MCP, summarize via LLM',
+      () async {
+        // Step 1: Use MCP to search
+        final searchResult = await mcp.executeTool(
+          'brave',
+          'brave_web_search',
+          {'query': 'Dart programming language features'},
+        );
 
-      expect(searchResult['isError'], isFalse);
-      final content = searchResult['content']! as List;
-      expect(content, isNotEmpty);
+        expect(searchResult['isError'], isFalse);
+        final content = searchResult['content']! as List;
+        expect(content, isNotEmpty);
 
-      // Step 2: Feed search results to LLM for summarization
-      final searchText = content.take(3).join('\n\n');
-      final summary = await llm.complete(
-        'Summarize these search results in one sentence:\n\n$searchText',
-        systemPrompt: 'You are a concise summarizer. Reply in one sentence.',
-        maxTokens: 4096,
-      );
+        // Step 2: Feed search results to LLM for summarization
+        final searchText = content.take(3).join('\n\n');
+        final summary = await llm.complete(
+          'Summarize these search results in one sentence:\n\n$searchText',
+          systemPrompt: 'You are a concise summarizer. Reply in one sentence.',
+          maxTokens: 4096,
+        );
 
-      expect(summary, isNotEmpty);
-      // The summary should be a coherent sentence, not empty garbage.
-      expect(summary.length, greaterThan(10));
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        expect(summary, isNotEmpty);
+        // The summary should be a coherent sentence, not empty garbage.
+        expect(summary.length, greaterThan(10));
+      },
+      timeout: const Timeout(
+        Duration(seconds: 60),
+      ),
+    );
 
-    test('chat with MCP context injection', () async {
-      // Step 1: Discover available tools
-      final tools = await mcp.listTools(serverId: 'brave');
-      final toolNames = tools.map((t) => t['name']).toList();
+    test(
+      'chat with MCP context injection',
+      () async {
+        // Step 1: Discover available tools
+        final tools = await mcp.listTools(serverId: 'brave');
+        final toolNames = tools.map((t) => t['name']).toList();
 
-      // Step 2: Ask LLM about the tools (simulates agent reasoning)
-      final response = await llm.chat(
-        [
-          (
-            role: 'user',
-            content: 'I have these MCP tools available: $toolNames. '
-                'Which one would I use to search the web?',
-          ),
-        ],
-        maxTokens: 4096,
-      );
+        // Step 2: Ask LLM about the tools (simulates agent reasoning)
+        final response = await llm.chat(
+          [
+            (
+              role: 'user',
+              content: 'I have these MCP tools available: $toolNames. '
+                  'Which one would I use to search the web?',
+            ),
+          ],
+          maxTokens: 4096,
+        );
 
-      expect(response, isNotEmpty);
-      expect(
-        response.toLowerCase(),
-        contains('brave_web_search'),
-        reason: 'LLM should identify brave_web_search as the web search tool',
-      );
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        expect(response, isNotEmpty);
+        expect(
+          response.toLowerCase(),
+          contains('brave_web_search'),
+          reason: 'LLM should identify brave_web_search as the web search tool',
+        );
+      },
+      timeout: const Timeout(
+        Duration(seconds: 60),
+      ),
+    );
   });
 }

--- a/packages/soliplex_mcp/test/src/mcp_connection_manager_integration_test.dart
+++ b/packages/soliplex_mcp/test/src/mcp_connection_manager_integration_test.dart
@@ -1,4 +1,6 @@
 @Tags(['integration'])
+library;
+
 import 'dart:io';
 
 import 'package:soliplex_mcp/soliplex_mcp.dart';
@@ -13,7 +15,7 @@ import 'package:test/test.dart';
 ///
 /// Run:
 ///   cd packages/soliplex_mcp
-///   BRAVE_API_KEY=<key> dart test --tags=integration --run-skipped
+///   BRAVE_API_KEY=`<key>` dart test --tags=integration --run-skipped
 void main() {
   final apiKey = Platform.environment['BRAVE_API_KEY'];
 
@@ -28,7 +30,7 @@ void main() {
       serverConfigs: {
         'brave': McpServerConfig.stdio(
           command: 'npx',
-          args: ['-y', '@brave/brave-search-mcp-server'],
+          args: const ['-y', '@brave/brave-search-mcp-server'],
           environment: {
             ...Platform.environment,
             'BRAVE_API_KEY': apiKey,
@@ -43,48 +45,56 @@ void main() {
   });
 
   group('McpConnectionManager + Brave Search integration', () {
-    test('listServers returns brave as disconnected before first use',
-        () async {
-      // Re-create a fresh manager to test initial state.
-      final fresh = McpConnectionManager(
-        serverConfigs: {
-          'brave': McpServerConfig.stdio(
-            command: 'npx',
-            args: ['-y', '@brave/brave-search-mcp-server'],
-            environment: {
-              ...Platform.environment,
-              'BRAVE_API_KEY': apiKey!,
-            },
-          ),
-        },
-      );
+    test(
+      'listServers returns brave as disconnected before first use',
+      () async {
+        // Re-create a fresh manager to test initial state.
+        final fresh = McpConnectionManager(
+          serverConfigs: {
+            'brave': McpServerConfig.stdio(
+              command: 'npx',
+              args: const ['-y', '@brave/brave-search-mcp-server'],
+              environment: {
+                ...Platform.environment,
+                'BRAVE_API_KEY': apiKey!,
+              },
+            ),
+          },
+        );
 
-      final servers = await fresh.listServers();
-      expect(servers, hasLength(1));
-      expect(servers.first['id'], 'brave');
-      expect(servers.first['kind'], 'stdio');
-      expect(servers.first['status'], 'disconnected');
-      await fresh.dispose();
-    });
+        final servers = await fresh.listServers();
+        expect(servers, hasLength(1));
+        expect(servers.first['id'], 'brave');
+        expect(servers.first['kind'], 'stdio');
+        expect(servers.first['status'], 'disconnected');
+        await fresh.dispose();
+      },
+    );
 
-    test('listTools discovers brave_web_search tool', () async {
-      final tools = await manager.listTools(serverId: 'brave');
+    test(
+      'listTools discovers brave_web_search tool',
+      () async {
+        final tools = await manager.listTools(serverId: 'brave');
 
-      expect(tools, isNotEmpty);
-      final names = tools.map((t) => t['name']).toSet();
-      expect(
-        names,
-        contains('brave_web_search'),
-        reason: 'Brave MCP should expose brave_web_search tool',
-      );
+        expect(tools, isNotEmpty);
+        final names = tools.map((t) => t['name']).toSet();
+        expect(
+          names,
+          contains('brave_web_search'),
+          reason: 'Brave MCP should expose brave_web_search tool',
+        );
 
-      // Each tool entry should have required fields.
-      for (final tool in tools) {
-        expect(tool['server'], 'brave');
-        expect(tool['name'], isA<String>());
-        expect(tool['description'], isA<String>());
-      }
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        // Each tool entry should have required fields.
+        for (final tool in tools) {
+          expect(tool['server'], 'brave');
+          expect(tool['name'], isA<String>());
+          expect(tool['description'], isA<String>());
+        }
+      },
+      timeout: const Timeout(
+        Duration(seconds: 60),
+      ),
+    );
 
     test('listServers shows brave as connected after listTools', () async {
       // listTools above triggered the lazy connection.
@@ -93,38 +103,50 @@ void main() {
       expect(brave['status'], 'connected');
     });
 
-    test('executeTool brave_web_search returns results', () async {
-      final result = await manager.executeTool(
-        'brave',
-        'brave_web_search',
-        {'query': 'Flutter MCP integration'},
-      );
-
-      expect(result['isError'], isFalse);
-      expect(result['content'], isA<List>());
-      final content = result['content']! as List;
-      expect(content, isNotEmpty, reason: 'Search should return results');
-
-      // Content items should be text strings.
-      final firstItem = content.first as String;
-      expect(firstItem, isNotEmpty);
-    }, timeout: const Timeout(Duration(seconds: 30)));
-
-    test('executeTool with unknown tool returns error', () async {
-      // MCP spec: calling a nonexistent tool should produce an error result
-      // (not throw).
-      try {
+    test(
+      'executeTool brave_web_search returns results',
+      () async {
         final result = await manager.executeTool(
           'brave',
-          'nonexistent_tool_xyz',
-          {},
+          'brave_web_search',
+          {'query': 'Flutter MCP integration'},
         );
-        // If it returns rather than throws, isError should be true.
-        expect(result['isError'], isTrue);
-      } on Exception {
-        // Some servers may throw — that's acceptable too.
-      }
-    }, timeout: const Timeout(Duration(seconds: 15)));
+
+        expect(result['isError'], isFalse);
+        expect(result['content'], isA<List<Object?>>());
+        final content = result['content']! as List;
+        expect(content, isNotEmpty, reason: 'Search should return results');
+
+        // Content items should be text strings.
+        final firstItem = content.first as String;
+        expect(firstItem, isNotEmpty);
+      },
+      timeout: const Timeout(
+        Duration(seconds: 30),
+      ),
+    );
+
+    test(
+      'executeTool with unknown tool returns error',
+      () async {
+        // MCP spec: calling a nonexistent tool should produce an error result
+        // (not throw).
+        try {
+          final result = await manager.executeTool(
+            'brave',
+            'nonexistent_tool_xyz',
+            {},
+          );
+          // If it returns rather than throws, isError should be true.
+          expect(result['isError'], isTrue);
+        } on Exception {
+          // Some servers may throw — that's acceptable too.
+        }
+      },
+      timeout: const Timeout(
+        Duration(seconds: 15),
+      ),
+    );
 
     test('unknown server throws ArgumentError', () async {
       await expectLater(
@@ -133,25 +155,31 @@ void main() {
       );
     });
 
-    test('dispose closes connection without error', () async {
-      // Create a separate manager, connect it, then dispose.
-      final disposable = McpConnectionManager(
-        serverConfigs: {
-          'brave': McpServerConfig.stdio(
-            command: 'npx',
-            args: ['-y', '@brave/brave-search-mcp-server'],
-            environment: {
-              ...Platform.environment,
-              'BRAVE_API_KEY': apiKey!,
-            },
-          ),
-        },
-      );
+    test(
+      'dispose closes connection without error',
+      () async {
+        // Create a separate manager, connect it, then dispose.
+        final disposable = McpConnectionManager(
+          serverConfigs: {
+            'brave': McpServerConfig.stdio(
+              command: 'npx',
+              args: const ['-y', '@brave/brave-search-mcp-server'],
+              environment: {
+                ...Platform.environment,
+                'BRAVE_API_KEY': apiKey!,
+              },
+            ),
+          },
+        );
 
-      // Force connection.
-      await disposable.listTools(serverId: 'brave');
-      // Dispose should not throw.
-      await disposable.dispose();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        // Force connection.
+        await disposable.listTools(serverId: 'brave');
+        // Dispose should not throw.
+        await disposable.dispose();
+      },
+      timeout: const Timeout(
+        Duration(seconds: 60),
+      ),
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Fix all `dart analyze --fatal-infos` issues in integration test files from PR #133

## Changes
- **library_annotations**: Add `library;` directive for `@Tags` annotation
- **require_trailing_commas**: Add missing trailing commas
- **strict_raw_type**: `isA<List>()` → `isA<List<Object?>>()`
- **unintended_html_in_doc_comment**: Escape `<key>` with backticks in doc comments
- **prefer_const_literals_to_create_immutables**: Applied via `dart fix`

## Test plan
- [x] `dart analyze --fatal-infos` passes with 0 issues in soliplex_completions, soliplex_mcp, soliplex_scripting
- [x] `dart format . --set-exit-if-changed` passes in all three packages