### PR TITLE
feat(tui): wire Phase 2 direct completions + MCP

### DIFF
--- a/packages/soliplex_tui/bin/soliplex_tui.dart
+++ b/packages/soliplex_tui/bin/soliplex_tui.dart
@@ -67,6 +67,26 @@ Future<void> main(List<String> arguments) async {
       'tools',
       help: 'Comma-separated tool names to advertise (default: all).',
     )
+    ..addOption(
+      'llm-provider',
+      help: 'LLM provider: ollama, anthropic, openai (requires --monty).',
+    )
+    ..addOption(
+      'llm-model',
+      help: 'LLM model name (provider-specific default if omitted).',
+    )
+    ..addOption(
+      'llm-url',
+      help: 'LLM API base URL (provider-specific default if omitted).',
+    )
+    ..addOption(
+      'llm-api-key',
+      help: 'LLM API key (or set ANTHROPIC_API_KEY / OPENAI_API_KEY).',
+    )
+    ..addMultiOption(
+      'mcp',
+      help: 'MCP server: name=command args... (repeatable, requires --monty).',
+    )
     ..addFlag('help', abbr: 'h', negatable: false, help: 'Show usage');
 
   final ArgResults results;
@@ -103,6 +123,12 @@ Future<void> main(List<String> arguments) async {
   final toolsFilter = results.option('tools');
   final enabledTools = toolsFilter?.split(',').map((s) => s.trim()).toSet();
 
+  final llmProvider = results.option('llm-provider');
+  final llmModel = results.option('llm-model');
+  final llmUrl = results.option('llm-url');
+  final llmApiKey = results.option('llm-api-key');
+  final mcpServers = results.multiOption('mcp');
+
   final prompts = results.multiOption('prompt');
   if (prompts.isNotEmpty) {
     await runHeadless(
@@ -117,6 +143,11 @@ Future<void> main(List<String> arguments) async {
       montyEnabled: montyEnabled,
       noTools: noTools,
       enabledTools: enabledTools,
+      llmProvider: llmProvider,
+      llmModel: llmModel,
+      llmUrl: llmUrl,
+      llmApiKey: llmApiKey,
+      mcpServers: mcpServers,
     );
     return;
   }
@@ -143,6 +174,11 @@ Future<void> main(List<String> arguments) async {
       montyEnabled: montyEnabled,
       noTools: noTools,
       enabledTools: enabledTools,
+      llmProvider: llmProvider,
+      llmModel: llmModel,
+      llmUrl: llmUrl,
+      llmApiKey: llmApiKey,
+      mcpServers: mcpServers,
     );
     return;
   }
@@ -154,5 +190,10 @@ Future<void> main(List<String> arguments) async {
     montyEnabled: montyEnabled,
     noTools: noTools,
     enabledTools: enabledTools,
+    llmProvider: llmProvider,
+    llmModel: llmModel,
+    llmUrl: llmUrl,
+    llmApiKey: llmApiKey,
+    mcpServers: mcpServers,
   );
 }

--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -9,7 +9,9 @@ import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_client/soliplex_client.dart'
     show DartHttpClient, SoliplexApi, ToolCallInfo;
+import 'package:soliplex_completions/soliplex_completions.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
+import 'package:soliplex_mcp/soliplex_mcp.dart';
 import 'package:soliplex_scripting/soliplex_scripting.dart';
 
 import 'package:soliplex_tui/src/components/chat_page.dart';
@@ -31,6 +33,11 @@ Future<void> launchTui({
   bool montyEnabled = false,
   bool noTools = false,
   Set<String>? enabledTools,
+  String? llmProvider,
+  String? llmModel,
+  String? llmUrl,
+  String? llmApiKey,
+  List<String> mcpServers = const [],
 }) async {
   final fileSink = FileSink(filePath: logFile);
   LogManager.instance
@@ -46,6 +53,7 @@ Future<void> launchTui({
   );
 
   AgentRuntime? runtime;
+  McpConnectionManager? mcpManager;
   try {
     final resolvedRoomId = await _resolveRoom(connection.api, roomId);
     Loggers.app.info('Resolved room: $resolvedRoomId');
@@ -54,8 +62,15 @@ Future<void> launchTui({
         ? const ToolRegistry()
         : buildDemoToolRegistry(enabledTools: enabledTools);
 
-    final (:extensionFactory, :bindAgentApi) =
-        _buildMontyWiring(montyEnabled: montyEnabled);
+    final wiring = _buildMontyWiring(
+      montyEnabled: montyEnabled,
+      llmProvider: llmProvider,
+      llmModel: llmModel,
+      llmUrl: llmUrl,
+      llmApiKey: llmApiKey,
+      mcpServers: mcpServers,
+    );
+    mcpManager = wiring.mcpManager;
 
     final uiDelegate = TuiUiDelegate();
 
@@ -64,11 +79,11 @@ Future<void> launchTui({
       toolRegistryResolver: (_) async => toolRegistry,
       platform: const NativePlatformConstraints(),
       logger: Loggers.agui,
-      extensionFactory: extensionFactory,
+      extensionFactory: wiring.extensionFactory,
       uiDelegate: uiDelegate,
     );
 
-    bindAgentApi(runtime);
+    wiring.bindAgentApi(runtime);
 
     await runApp(
       SoliplexTuiApp(
@@ -81,6 +96,7 @@ Future<void> launchTui({
     Loggers.app.error('Fatal error', error: e, stackTrace: s);
     rethrow;
   } finally {
+    await mcpManager?.dispose();
     await runtime?.dispose();
     await LogManager.instance.flush();
     await LogManager.instance.close();
@@ -113,6 +129,11 @@ Future<void> runHeadless({
   bool montyEnabled = false,
   bool noTools = false,
   Set<String>? enabledTools,
+  String? llmProvider,
+  String? llmModel,
+  String? llmUrl,
+  String? llmApiKey,
+  List<String> mcpServers = const [],
 }) async {
   final fileSink = FileSink(filePath: logFile);
   LogManager.instance
@@ -132,6 +153,7 @@ Future<void> runHeadless({
     httpClient: DartHttpClient(),
   );
   AgentRuntime? runtime;
+  McpConnectionManager? mcpManager;
 
   try {
     final resolvedRoomId = roomId ?? (await _resolveRoom(connection.api, null));
@@ -145,19 +167,26 @@ Future<void> runHeadless({
         ? const ToolRegistry()
         : buildDemoToolRegistry(enabledTools: enabledTools);
 
-    final (:extensionFactory, :bindAgentApi) =
-        _buildMontyWiring(montyEnabled: montyEnabled);
+    final wiring = _buildMontyWiring(
+      montyEnabled: montyEnabled,
+      llmProvider: llmProvider,
+      llmModel: llmModel,
+      llmUrl: llmUrl,
+      llmApiKey: llmApiKey,
+      mcpServers: mcpServers,
+    );
+    mcpManager = wiring.mcpManager;
 
     runtime = AgentRuntime(
       connection: connection,
       toolRegistryResolver: (_) async => toolRegistry,
       platform: const NativePlatformConstraints(),
       logger: Loggers.agui,
-      extensionFactory: extensionFactory,
+      extensionFactory: wiring.extensionFactory,
       uiDelegate: autoApprove ? const AutoApproveUiDelegate() : null,
     );
 
-    bindAgentApi(runtime);
+    wiring.bindAgentApi(runtime);
 
     if (json) {
       await _runHeadlessJson(
@@ -197,6 +226,7 @@ Future<void> runHeadless({
     }
     exit(1);
   } finally {
+    await mcpManager?.dispose();
     await runtime?.dispose();
     await LogManager.instance.flush();
     await LogManager.instance.close();
@@ -331,19 +361,42 @@ Future<void> listRooms({
   }
 }
 
-/// Builds Monty wiring when enabled, returning the extension factory and a
-/// callback to bind the [AgentApi] after runtime creation.
+/// Builds Monty wiring when enabled, returning the extension factory, a
+/// callback to bind the [AgentApi] after runtime creation, and an optional
+/// [McpConnectionManager] that the caller must dispose.
 ({
   SessionExtensionFactory? extensionFactory,
   void Function(AgentRuntime) bindAgentApi,
-}) _buildMontyWiring({required bool montyEnabled}) {
+  McpConnectionManager? mcpManager,
+}) _buildMontyWiring({
+  required bool montyEnabled,
+  String? llmProvider,
+  String? llmModel,
+  String? llmUrl,
+  String? llmApiKey,
+  List<String> mcpServers = const [],
+}) {
   if (!montyEnabled) {
-    return (extensionFactory: null, bindAgentApi: (_) {});
+    return (extensionFactory: null, bindAgentApi: (_) {}, mcpManager: null);
   }
 
   MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
   final blackboardApi = DirectBlackboardApi();
   AgentApi? agentApi;
+
+  // Phase 2: direct LLM completions (bypasses backend).
+  final provider = _createLlmProvider(
+    provider: llmProvider,
+    model: llmModel,
+    url: llmUrl,
+    apiKey: llmApiKey,
+  );
+
+  // Phase 2: MCP connection manager.
+  final mcpConfigs = _parseMcpServers(mcpServers);
+  final mcpManager = mcpConfigs.isNotEmpty
+      ? McpConnectionManager(serverConfigs: mcpConfigs)
+      : null;
 
   return (
     extensionFactory: () async {
@@ -353,6 +406,20 @@ Future<void> listRooms({
         agentApi: agentApi,
         blackboardApi: blackboardApi,
         limits: MontyLimitsDefaults.tool,
+        llmCompleter: provider?.complete,
+        llmChatCompleter: provider != null
+            ? (messages, {systemPrompt, maxTokens}) => provider.chat(
+                  [
+                    for (final m in messages)
+                      (role: m['role']!, content: m['content']!),
+                  ],
+                  systemPrompt: systemPrompt,
+                  maxTokens: maxTokens,
+                )
+            : null,
+        mcpExecutor: mcpManager?.executeTool,
+        mcpToolLister: mcpManager?.listTools,
+        mcpServerLister: mcpManager?.listServers,
       );
       final env = await factory();
       return [
@@ -363,7 +430,71 @@ Future<void> listRooms({
     bindAgentApi: (AgentRuntime runtime) {
       agentApi = RuntimeAgentApi(runtime: runtime);
     },
+    mcpManager: mcpManager,
   );
+}
+
+/// Creates an [LlmProvider] from CLI flags, or returns `null` if no
+/// provider was specified.
+LlmProvider? _createLlmProvider({
+  String? provider,
+  String? model,
+  String? url,
+  String? apiKey,
+}) {
+  if (provider == null) return null;
+  return switch (provider) {
+    'anthropic' => AnthropicLlmProvider(
+        apiKey: apiKey ??
+            Platform.environment['ANTHROPIC_API_KEY'] ??
+            (throw ArgumentError(
+              'Anthropic requires --llm-api-key or ANTHROPIC_API_KEY',
+            )),
+        model: model ?? 'claude-sonnet-4-20250514',
+      ),
+    'openai' => OpenAiLlmProvider(
+        apiKey: apiKey ??
+            Platform.environment['OPENAI_API_KEY'] ??
+            (throw ArgumentError(
+              'OpenAI requires --llm-api-key or OPENAI_API_KEY',
+            )),
+        model: model ?? 'gpt-4o',
+        baseUrl: url,
+      ),
+    'ollama' => OllamaLlmProvider(
+        model: model ?? 'llama3.2',
+        baseUrl: url ?? 'http://localhost:11434/api',
+      ),
+    _ => throw ArgumentError('Unknown LLM provider: $provider'),
+  };
+}
+
+/// Parses `--mcp name=command args...` specs into a config map.
+///
+/// If the value starts with `http://` or `https://`, an HTTP transport is
+/// used; otherwise it is treated as a stdio command.
+Map<String, McpServerConfig> _parseMcpServers(List<String> specs) {
+  final configs = <String, McpServerConfig>{};
+  for (final spec in specs) {
+    final eqIndex = spec.indexOf('=');
+    if (eqIndex < 1) {
+      throw FormatException(
+        'Invalid --mcp format: $spec (expected name=command args...)',
+      );
+    }
+    final name = spec.substring(0, eqIndex);
+    final rest = spec.substring(eqIndex + 1).trim();
+    if (rest.startsWith('http://') || rest.startsWith('https://')) {
+      configs[name] = McpServerConfig.http(url: rest);
+    } else {
+      final parts = rest.split(' ');
+      configs[name] = McpServerConfig.stdio(
+        command: parts.first,
+        args: parts.skip(1).toList(),
+      );
+    }
+  }
+  return configs;
 }
 
 /// Resolves the room ID — uses the provided ID or picks the first available.

--- a/packages/soliplex_tui/pubspec.yaml
+++ b/packages/soliplex_tui/pubspec.yaml
@@ -25,12 +25,16 @@ dependencies:
     path: ../soliplex_agent
   soliplex_client:
     path: ../soliplex_client
+  soliplex_completions:
+    path: ../soliplex_completions
   soliplex_dataframe:
     path: ../soliplex_dataframe
   soliplex_interpreter_monty:
     path: ../soliplex_interpreter_monty
   soliplex_logging:
     path: ../soliplex_logging
+  soliplex_mcp:
+    path: ../soliplex_mcp
   soliplex_scripting:
     path: ../soliplex_scripting
 


### PR DESCRIPTION
## Summary
- Wire `soliplex_completions` and `soliplex_mcp` into `soliplex_tui` for Phase 2 direct LLM completions and MCP tool servers
- Add 5 new CLI flags: `--llm-provider`, `--llm-model`, `--llm-url`, `--llm-api-key`, `--mcp`
- When used with `--monty`, Monty scripts gain access to `llm_complete()`, `llm_chat()`, `mcp_call_tool()`, `mcp_list_tools()`, `mcp_list_servers()` backed by direct SDK calls (no backend routing)

## Changes
- **pubspec.yaml**: Added `soliplex_completions` and `soliplex_mcp` path dependencies
- **bin/soliplex_tui.dart**: New CLI flags parsed and passed through all 3 entry paths (`--prompt`, `--debug`, `launchTui`)
- **lib/src/app.dart**:
  - `_buildMontyWiring()` extended to create `LlmProvider` and `McpConnectionManager` from CLI flags
  - `_createLlmProvider()` — factory for anthropic/openai/ollama with env var fallback
  - `_parseMcpServers()` — parses `name=command args...` or `name=https://...` specs
  - `McpConnectionManager` lifecycle managed in `finally` blocks
  - `LlmChatCompleter` adapter bridges `LlmProvider.chat()` record types to `Map<String,String>` typedef

## Test plan
- [x] `dart analyze` — 0 issues
- [x] `dart format` — clean
- [x] `dart test` — 51/51 pass
- [x] AOT compile succeeds
- [x] `--help` shows all new flags
- [x] Headless smoke test (no monty) against demo.toughserv.com
- [x] Monty + Ollama smoke test: `execute_python` tool called successfully with rebuilt dart_monty native lib