### PR TITLE
feat(tui): bridge struct_log into soliplex_logging

### DIFF
--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -14,13 +14,14 @@ import 'package:soliplex_completions/soliplex_completions.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_mcp/soliplex_mcp.dart';
 import 'package:soliplex_scripting/soliplex_scripting.dart';
-
 import 'package:soliplex_tui/src/components/chat_page.dart';
 import 'package:soliplex_tui/src/file_sink.dart';
 import 'package:soliplex_tui/src/host/tui_host_api.dart';
 import 'package:soliplex_tui/src/loggers.dart';
 import 'package:soliplex_tui/src/services/tui_ui_delegate.dart';
+import 'package:soliplex_tui/src/struct_log_bridge_sink.dart';
 import 'package:soliplex_tui/src/tool_definitions.dart';
+import 'package:struct_log/struct_log.dart' as stl;
 
 /// Launches the Soliplex TUI application.
 ///
@@ -44,6 +45,12 @@ Future<void> launchTui({
   LogManager.instance
     ..minimumLevel = LogLevel.trace
     ..addSink(fileSink);
+
+  // Bridge struct_log (used by dart_monty_bridge) into soliplex_logging so
+  // Monty interpreter logs appear in the TUI log file.
+  stl.LogManager.instance
+    ..minimumLevel = stl.LogLevel.trace
+    ..addSink(StructLogBridgeSink());
 
   Loggers.app.info('Starting TUI, server=$serverUrl, logFile=$logFile');
 
@@ -107,6 +114,7 @@ Future<void> launchTui({
   } finally {
     await mcpManager?.dispose();
     await runtime?.dispose();
+    await stl.LogManager.instance.close();
     await LogManager.instance.flush();
     await LogManager.instance.close();
     await connection.close();
@@ -151,6 +159,12 @@ Future<void> runHeadless({
   if (verbose) {
     LogManager.instance.addSink(_StderrSink());
   }
+
+  // Bridge struct_log (used by dart_monty_bridge) into soliplex_logging so
+  // Monty interpreter logs appear in the TUI log file.
+  stl.LogManager.instance
+    ..minimumLevel = stl.LogLevel.trace
+    ..addSink(StructLogBridgeSink());
 
   Loggers.app.info(
     'Starting headless mode, server=$serverUrl, logFile=$logFile',
@@ -245,6 +259,7 @@ Future<void> runHeadless({
   } finally {
     await mcpManager?.dispose();
     await runtime?.dispose();
+    await stl.LogManager.instance.close();
     await LogManager.instance.flush();
     await LogManager.instance.close();
     await connection.close();

--- a/packages/soliplex_tui/lib/src/struct_log_bridge_sink.dart
+++ b/packages/soliplex_tui/lib/src/struct_log_bridge_sink.dart
@@ -1,0 +1,50 @@
+import 'package:soliplex_logging/soliplex_logging.dart' as sl;
+import 'package:struct_log/struct_log.dart' as stl;
+
+/// Adapter that forwards [stl.LogRecord]s from `struct_log` into the
+/// `soliplex_logging` [sl.LogManager].
+///
+/// Register with `stl.LogManager.instance.addSink(StructLogBridgeSink())` to
+/// route all dart_monty_bridge / PluginRegistry logs into the TUI's log file
+/// and any other soliplex sinks.
+class StructLogBridgeSink implements stl.LogSink {
+  /// Creates a bridge sink that writes to the given [sl.LogManager].
+  ///
+  /// Defaults to [sl.LogManager.instance].
+  StructLogBridgeSink({sl.LogManager? target})
+      : _target = target ?? sl.LogManager.instance;
+
+  final sl.LogManager _target;
+
+  @override
+  void write(stl.LogRecord record) {
+    _target.emit(
+      sl.LogRecord(
+        level: _mapLevel(record.level),
+        message: record.message,
+        timestamp: record.timestamp,
+        loggerName: 'monty.${record.loggerName}',
+        error: record.error,
+        stackTrace: record.stackTrace,
+        spanId: record.spanId,
+        traceId: record.traceId,
+        attributes: record.attributes,
+      ),
+    );
+  }
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
+
+  static sl.LogLevel _mapLevel(stl.LogLevel level) => switch (level) {
+        stl.LogLevel.trace => sl.LogLevel.trace,
+        stl.LogLevel.debug => sl.LogLevel.debug,
+        stl.LogLevel.info => sl.LogLevel.info,
+        stl.LogLevel.warning => sl.LogLevel.warning,
+        stl.LogLevel.error => sl.LogLevel.error,
+        stl.LogLevel.fatal => sl.LogLevel.fatal,
+      };
+}

--- a/packages/soliplex_tui/pubspec.yaml
+++ b/packages/soliplex_tui/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
     path: ../soliplex_mcp
   soliplex_scripting:
     path: ../soliplex_scripting
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
 
 dev_dependencies:
   mocktail: ^1.0.0

--- a/packages/soliplex_tui/test/src/struct_log_bridge_sink_test.dart
+++ b/packages/soliplex_tui/test/src/struct_log_bridge_sink_test.dart
@@ -1,0 +1,127 @@
+import 'package:soliplex_logging/soliplex_logging.dart' as sl;
+import 'package:soliplex_tui/src/struct_log_bridge_sink.dart';
+import 'package:struct_log/struct_log.dart' as stl;
+import 'package:test/test.dart';
+
+void main() {
+  group('StructLogBridgeSink', () {
+    late sl.LogManager slManager;
+    late _CaptureSink capture;
+
+    setUp(() {
+      slManager = sl.LogManager.instance..reset();
+      capture = _CaptureSink();
+      slManager
+        ..minimumLevel = sl.LogLevel.trace
+        ..addSink(capture);
+    });
+
+    tearDown(() {
+      slManager.reset();
+      stl.LogManager.instance.reset();
+    });
+
+    test('forwards struct_log records to soliplex_logging', () {
+      final bridge = StructLogBridgeSink(target: slManager);
+      stl.LogManager.instance
+        ..minimumLevel = stl.LogLevel.trace
+        ..addSink(bridge);
+
+      stl.LogManager.instance.getLogger('Bridge').info('hello from struct_log');
+
+      expect(capture.records, hasLength(1));
+      expect(capture.records.first.message, 'hello from struct_log');
+      expect(capture.records.first.loggerName, 'monty.Bridge');
+      expect(capture.records.first.level, sl.LogLevel.info);
+    });
+
+    test('maps all log levels correctly', () {
+      final bridge = StructLogBridgeSink(target: slManager);
+      stl.LogManager.instance
+        ..minimumLevel = stl.LogLevel.trace
+        ..addSink(bridge);
+
+      stl.LogManager.instance.getLogger('Levels')
+        ..trace('t')
+        ..debug('d')
+        ..info('i')
+        ..warning('w')
+        ..error('e')
+        ..fatal('f');
+
+      expect(capture.records.map((r) => r.level).toList(), [
+        sl.LogLevel.trace,
+        sl.LogLevel.debug,
+        sl.LogLevel.info,
+        sl.LogLevel.warning,
+        sl.LogLevel.error,
+        sl.LogLevel.fatal,
+      ]);
+    });
+
+    test('preserves error, stackTrace, and attributes', () {
+      final bridge = StructLogBridgeSink(target: slManager);
+      stl.LogManager.instance
+        ..minimumLevel = stl.LogLevel.trace
+        ..addSink(bridge);
+
+      final err = StateError('boom');
+      final trace = StackTrace.current;
+      stl.LogManager.instance.getLogger('Err').error(
+        'failed',
+        error: err,
+        stackTrace: trace,
+        attributes: {'key': 'value'},
+      );
+
+      expect(capture.records, hasLength(1));
+      final record = capture.records.first;
+      expect(record.error, err);
+      expect(record.stackTrace, trace);
+      expect(record.attributes, {'key': 'value'});
+    });
+
+    test('preserves spanId and traceId', () {
+      final bridge = StructLogBridgeSink(target: slManager);
+      stl.LogManager.instance
+        ..minimumLevel = stl.LogLevel.trace
+        ..addSink(bridge);
+
+      stl.LogManager.instance.getLogger('Otel').info(
+            'traced',
+            spanId: 'span-123',
+            traceId: 'trace-456',
+          );
+
+      final record = capture.records.first;
+      expect(record.spanId, 'span-123');
+      expect(record.traceId, 'trace-456');
+    });
+
+    test('prefixes loggerName with monty.', () {
+      final bridge = StructLogBridgeSink(target: slManager);
+      stl.LogManager.instance
+        ..minimumLevel = stl.LogLevel.trace
+        ..addSink(bridge);
+
+      stl.LogManager.instance.getLogger('PluginRegistry').debug(
+            'registering plugin',
+          );
+
+      expect(capture.records.first.loggerName, 'monty.PluginRegistry');
+    });
+  });
+}
+
+class _CaptureSink implements sl.LogSink {
+  final records = <sl.LogRecord>[];
+
+  @override
+  void write(sl.LogRecord record) => records.add(record);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
+}


### PR DESCRIPTION
## Summary
- Add `StructLogBridgeSink` adapter that forwards `struct_log` records (used by `dart_monty_bridge`) into `soliplex_logging`, making Monty interpreter logs visible in the TUI log file
- Logger names prefixed with `monty.` (e.g. `monty.DefaultMontyBridge`, `monty.PluginRegistry`) for easy filtering
- Wired into both `launchTui()` and `runHeadless()` entry points with proper lifecycle cleanup

## Changes
- **`struct_log_bridge_sink.dart`**: New adapter implementing `struct_log.LogSink`, maps all fields (level, message, timestamp, error, stackTrace, spanId, traceId, attributes) faithfully between the two logging systems
- **`app.dart`**: Register bridge sink in both `launchTui()` and `runHeadless()`, close `struct_log.LogManager` in finally blocks
- **`pubspec.yaml`**: Add `struct_log` git dependency to `soliplex_tui`

## Gemini review
4 PASS, 1 WARNING (theoretical double-registration if entry points called multiple times in same process — not applicable for CLI usage)

## Test plan
- [x] 5 unit tests: record forwarding, all 6 level mappings, error/stackTrace/attributes, spanId/traceId, monty. prefix
- [x] Full suite: 63/63 tests pass
- [x] `dart analyze --fatal-infos`: zero issues
- [x] Pre-commit hooks pass