### PR TITLE
fix(tui): prevent -p flag from splitting on commas

### DIFF
--- a/packages/soliplex_tui/bin/soliplex_tui.dart
+++ b/packages/soliplex_tui/bin/soliplex_tui.dart
@@ -22,8 +22,11 @@ Future<void> main(List<String> arguments) async {
     ..addMultiOption(
       'prompt',
       abbr: 'p',
+      splitCommas: false,
       help: 'Send message(s) headless, print each response, and exit. '
-          'Repeatable for multi-turn conversations.',
+          'Repeatable for multi-turn conversations. '
+          'Use -p "value" form for multi-line content '
+          '(--prompt=value may drop newlines).',
     )
     ..addFlag(
       'debug',

--- a/packages/soliplex_tui/test/src/prompt_parsing_test.dart
+++ b/packages/soliplex_tui/test/src/prompt_parsing_test.dart
@@ -1,0 +1,59 @@
+import 'package:args/args.dart';
+import 'package:test/test.dart';
+
+/// Mirrors the parser config in bin/soliplex_tui.dart for the --prompt option.
+ArgParser _buildParser() => ArgParser()
+  ..addMultiOption(
+    'prompt',
+    abbr: 'p',
+    splitCommas: false,
+    help: 'Send message(s) headless, print each response, and exit. '
+        'Repeatable for multi-turn conversations. '
+        'Use -p "value" form for multi-line content '
+        '(--prompt=value may drop newlines).',
+  );
+
+void main() {
+  group('prompt flag parsing', () {
+    late ArgParser parser;
+
+    setUp(() {
+      parser = _buildParser();
+    });
+
+    test('single -p produces one prompt', () {
+      final results = parser.parse(['-p', 'hello']);
+      expect(results.multiOption('prompt'), ['hello']);
+    });
+
+    test('multiple -p produces multiple turns', () {
+      final results = parser.parse(['-p', 'msg1', '-p', 'msg2']);
+      expect(results.multiOption('prompt'), ['msg1', 'msg2']);
+    });
+
+    test('commas in -p value are preserved (not split)', () {
+      final results = parser.parse(['-p', 'def foo(a, b):']);
+      expect(results.multiOption('prompt'), ['def foo(a, b):']);
+    });
+
+    test('newlines in -p value are preserved', () {
+      final results = parser.parse(['-p', 'line1\nline2\nline3']);
+      final prompts = results.multiOption('prompt');
+      expect(prompts, hasLength(1));
+      expect(prompts.first, contains('\n'));
+    });
+
+    test('multi-line code with commas stays as single prompt', () {
+      const code = 'def foo(a, b):\n    return a + b\n\nprint(foo(1, 2))';
+      final results = parser.parse(['-p', code]);
+      final prompts = results.multiOption('prompt');
+      expect(prompts, hasLength(1));
+      expect(prompts.first, code);
+    });
+
+    test('--prompt=value with commas is not split', () {
+      final results = parser.parse(['--prompt=a,b,c']);
+      expect(results.multiOption('prompt'), ['a,b,c']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `addMultiOption('prompt')` defaulted to `splitCommas: true`, silently splitting comma-containing content (e.g. `def foo(a, b):`) into separate conversation turns
- Set `splitCommas: false` so each `-p` value is preserved as a single prompt
- Updated help text documenting the `--prompt=value` newline limitation (upstream `args` package issue)

## Changes
- **`bin/soliplex_tui.dart`**: Add `splitCommas: false` to prompt option, update help text
- **`test/src/prompt_parsing_test.dart`**: 6 tests covering single prompt, multi-turn, commas preserved, newlines preserved, multi-line code with commas, `--prompt=` form

## Spike experiment
Empirically tested `args` 2.7.0 `addMultiOption` behavior:
- `-p "a,b,c"` with `splitCommas: true` → `["a", "b", "c"]` (3 elements — the bug)
- `-p "a,b,c"` with `splitCommas: false` → `["a,b,c"]` (1 element — fixed)
- `-p "line1\nline2"` → preserved as single element (both before/after)
- `--prompt="line1\nline2"` → `[]` silent data loss (upstream `args` bug, documented)

## Gemini review
3 PASS, 1 WARNING (low risk of breaking users who relied on comma-splitting for multi-turn — undocumented and unlikely)

## Test plan
- [x] 6 unit tests for arg parsing behavior
- [x] Full suite: 69/69 pass
- [x] `dart analyze --fatal-infos`: zero issues
- [x] Pre-commit hooks pass

Closes #152