### PR TITLE
feat(cli,tui): wire OpenResponsesLlmProvider into local mode

### DIFF
--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -249,21 +249,24 @@ Future<void> _runSession(ArgResults parsed) async {
   final montyEnabled = parsed.flag('monty');
   final wasmMode = parsed.flag('wasm-mode');
 
-  // Build the LLM provider: local (ChatFnLlmProvider) or backend (AgUi).
+  // Build the LLM provider: local (StreamingLlmProvider) or backend (AgUi).
   final AgentLlmProvider llmProvider;
   LlmProvider? completionsProvider;
   if (localMode) {
-    completionsProvider = _createLlmProvider(
+    final created = _createLocalProvider(
       providerName: llmProviderName,
       model: llmModel,
       baseUrl: llmUrl,
       apiKey: llmApiKey,
-    );
-    if (completionsProvider == null) return; // Error already printed.
-    llmProvider = ChatFnLlmProvider(
-      chatFn: completionsProvider.chat,
       systemPrompt: llmSystemPrompt,
     );
+    if (created == null) return; // Error already printed.
+    completionsProvider = created.completionsProvider;
+    llmProvider = created.agentProvider;
+    final stack = llmProvider is StreamingLlmProvider
+        ? 'streaming (open_responses)'
+        : 'text-based (legacy)';
+    logger.info('Local LLM: $llmProviderName via $stack');
   } else {
     llmProvider = AgUiLlmProvider(
       api: connection.api,
@@ -811,21 +814,36 @@ void _traceExecutionEvent(ExecutionEvent event) {
 
 String _short(String id) => id.length > 12 ? '${id.substring(0, 12)}...' : id;
 
-/// Creates an [LlmProvider] from CLI flags.
+/// Creates a local LLM provider pair from CLI flags.
 ///
 /// Returns `null` and prints an error if configuration is invalid
 /// (e.g. missing API key for Anthropic/OpenAI).
-LlmProvider? _createLlmProvider({
+///
+/// For Ollama and OpenAI, returns an [OpenResponsesLlmProvider] backed
+/// [StreamingLlmProvider] with native tool calling. For Anthropic (whose
+/// API is not OpenAI-compatible), falls back to [AnthropicLlmProvider]
+/// with [ChatFnLlmProvider].
+({LlmProvider completionsProvider, AgentLlmProvider agentProvider})?
+    _createLocalProvider({
   required String providerName,
   String? model,
   String? baseUrl,
   String? apiKey,
+  String? systemPrompt,
 }) {
   switch (providerName) {
     case 'ollama':
-      return OllamaLlmProvider(
+      final p = OpenResponsesLlmProvider.ollama(
         model: model ?? 'qwen3:8b',
-        baseUrl: baseUrl ?? 'http://localhost:11434/api',
+        baseUrl: baseUrl ?? 'http://localhost:11434/v1',
+        systemPrompt: systemPrompt,
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: StreamingLlmProvider(
+          chatFn: p.chatStream,
+          systemPrompt: systemPrompt,
+        ),
       );
     case 'anthropic':
       final key = apiKey ?? Platform.environment['ANTHROPIC_API_KEY'];
@@ -836,9 +854,16 @@ LlmProvider? _createLlmProvider({
         );
         return null;
       }
-      return AnthropicLlmProvider(
+      final p = AnthropicLlmProvider(
         apiKey: key,
         model: model ?? 'claude-sonnet-4-20250514',
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: ChatFnLlmProvider(
+          chatFn: p.chat,
+          systemPrompt: systemPrompt,
+        ),
       );
     case 'openai':
       final key = apiKey ?? Platform.environment['OPENAI_API_KEY'];
@@ -849,7 +874,18 @@ LlmProvider? _createLlmProvider({
         );
         return null;
       }
-      return OpenAiLlmProvider(apiKey: key, model: model ?? 'gpt-4o');
+      final p = OpenResponsesLlmProvider.openai(
+        apiKey: key,
+        model: model ?? 'gpt-4o',
+        systemPrompt: systemPrompt,
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: StreamingLlmProvider(
+          chatFn: p.chatStream,
+          systemPrompt: systemPrompt,
+        ),
+      );
     default:
       stderr.writeln('Unknown LLM provider: $providerName');
       return null;

--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -459,18 +459,21 @@ Future<void> listRooms({required String serverUrl}) async {
 }) {
   // Build the direct LLM provider regardless of Monty — it drives agent
   // runs whenever --llm-provider is set.
-  final provider = _createLlmProvider(
-    provider: llmProvider,
+  final created = _createLocalProvider(
+    providerName: llmProvider,
     model: llmModel,
-    url: llmUrl,
+    baseUrl: llmUrl,
     apiKey: llmApiKey,
+    systemPrompt: llmSystemPrompt,
   );
-  final agentLlmProvider = provider != null
-      ? ChatFnLlmProvider(
-          chatFn: provider.chat,
-          systemPrompt: llmSystemPrompt,
-        )
-      : null;
+  final provider = created?.completionsProvider;
+  final agentLlmProvider = created?.agentProvider;
+  if (agentLlmProvider != null) {
+    final stack = agentLlmProvider is StreamingLlmProvider
+        ? 'streaming (open_responses)'
+        : 'text-based (legacy)';
+    Loggers.app.info('Local LLM: $llmProvider via $stack');
+  }
 
   // MCP servers are also independent of Monty.
   final mcpConfigs = _parseMcpServers(mcpServers);
@@ -543,39 +546,72 @@ Future<void> listRooms({required String serverUrl}) async {
   );
 }
 
-/// Creates an [LlmProvider] from CLI flags, or returns `null` if no
-/// provider was specified.
-LlmProvider? _createLlmProvider({
-  String? provider,
+/// Creates a local LLM provider pair from CLI flags, or returns `null`
+/// if no provider was specified.
+///
+/// For Ollama and OpenAI, returns an [OpenResponsesLlmProvider] backed
+/// [StreamingLlmProvider] with native tool calling. For Anthropic (whose
+/// API is not OpenAI-compatible), falls back to [AnthropicLlmProvider]
+/// with [ChatFnLlmProvider].
+({LlmProvider completionsProvider, AgentLlmProvider agentProvider})?
+    _createLocalProvider({
+  String? providerName,
   String? model,
-  String? url,
+  String? baseUrl,
   String? apiKey,
+  String? systemPrompt,
 }) {
-  if (provider == null) return null;
-  return switch (provider) {
-    'anthropic' => AnthropicLlmProvider(
+  if (providerName == null) return null;
+  switch (providerName) {
+    case 'ollama':
+      final p = OpenResponsesLlmProvider.ollama(
+        model: model ?? 'llama3.2',
+        baseUrl: baseUrl ?? 'http://localhost:11434/v1',
+        systemPrompt: systemPrompt,
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: StreamingLlmProvider(
+          chatFn: p.chatStream,
+          systemPrompt: systemPrompt,
+        ),
+      );
+    case 'anthropic':
+      final p = AnthropicLlmProvider(
         apiKey: apiKey ??
             Platform.environment['ANTHROPIC_API_KEY'] ??
             (throw ArgumentError(
               'Anthropic requires --llm-api-key or ANTHROPIC_API_KEY',
             )),
         model: model ?? 'claude-sonnet-4-20250514',
-      ),
-    'openai' => OpenAiLlmProvider(
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: ChatFnLlmProvider(
+          chatFn: p.chat,
+          systemPrompt: systemPrompt,
+        ),
+      );
+    case 'openai':
+      final p = OpenResponsesLlmProvider.openai(
         apiKey: apiKey ??
             Platform.environment['OPENAI_API_KEY'] ??
             (throw ArgumentError(
               'OpenAI requires --llm-api-key or OPENAI_API_KEY',
             )),
         model: model ?? 'gpt-4o',
-        baseUrl: url,
-      ),
-    'ollama' => OllamaLlmProvider(
-        model: model ?? 'llama3.2',
-        baseUrl: url ?? 'http://localhost:11434/api',
-      ),
-    _ => throw ArgumentError('Unknown LLM provider: $provider'),
-  };
+        systemPrompt: systemPrompt,
+      );
+      return (
+        completionsProvider: p,
+        agentProvider: StreamingLlmProvider(
+          chatFn: p.chatStream,
+          systemPrompt: systemPrompt,
+        ),
+      );
+    default:
+      throw ArgumentError('Unknown LLM provider: $providerName');
+  }
 }
 
 /// Parses `--mcp name=command args...` specs into a config map.


### PR DESCRIPTION
## Summary
- Replace `_createLlmProvider` → `_createLocalProvider` in both CLI and TUI
- Ollama and OpenAI route through `OpenResponsesLlmProvider` + `StreamingLlmProvider` (native streaming tool calls)
- Anthropic stays on `AnthropicLlmProvider` + `ChatFnLlmProvider` (incompatible API)
- Adds diagnostic log line showing which provider stack was selected

## Changes
- **soliplex_cli/cli_runner.dart**: Replace factory + wiring with `_createLocalProvider` returning named record
- **soliplex_tui/app.dart**: Same factory replacement + log via `Loggers.app`

## Dependencies
- Requires PR #156 (`feat/open-responses-integration`) to be merged first — cherry-picked into this branch

## Test plan
- [x] `dart test` passes in soliplex_cli (16/16)
- [x] `dart test` passes in soliplex_tui (69/69)
- [x] `dart test` passes in soliplex_agent (390/390)
- [x] `dart test` passes in soliplex_completions (58/58)
- [x] `dart format` — no changes
- [x] `dart analyze --fatal-infos` — 0 issues
- [x] Gemini reviewed (5 iterations: correctness, Ollama specialist, Anthropic specialist, principal engineer, SRE)
- [x] Anthropic bug caught by Gemini R3 and fixed — kept on legacy path