### PR TITLE
fix(cli): use non-streaming for Ollama tool calls

### DIFF
--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -841,7 +841,23 @@ String _short(String id) => id.length > 12 ? '${id.substring(0, 12)}...' : id;
       return (
         completionsProvider: p,
         agentProvider: StreamingLlmProvider(
-          chatFn: p.chatStream,
+          // Use chatNonStreaming for Ollama: its /v1/responses streaming
+          // omits call_id from function_call_arguments.delta/done events,
+          // causing the open_responses library to crash on null→String cast.
+          // The non-streaming path returns complete responses with all fields.
+          chatFn: ({
+            required messages,
+            tools,
+            systemPrompt,
+            maxTokens,
+            abortTrigger,
+          }) =>
+              p.chatNonStreaming(
+            messages: messages,
+            tools: tools,
+            systemPrompt: systemPrompt,
+            maxTokens: maxTokens,
+          ),
           systemPrompt: systemPrompt,
         ),
       );


### PR DESCRIPTION
## Summary
- Ollama's `/v1/responses` streaming omits `call_id` from `function_call_arguments.delta/done` events
- The `open_responses` library does hard `as String` casts on these fields, crashing with `type 'Null' is not a subtype of type 'String' in type cast`
- Switch Ollama provider to use `chatNonStreaming` which returns complete responses with all fields populated

## Root Cause
Ollama's Responses API streaming events differ from OpenAI's spec:

```json
// OpenAI includes call_id in delta events:
{"call_id": "call_abc", "delta": "{\"code\":\"print(42)\"}", ...}

// Ollama omits call_id from delta/done events:
{"delta": "{\"code\":\"print(42)\"}", "item_id": "fc_321815_0", ...}
```

The `call_id` is only present in the `response.output_item.added` event's `item` object, not in the subsequent argument delta/done events. The non-streaming complete response includes all fields correctly.

## Changes
- **`packages/soliplex_cli/lib/src/cli_runner.dart`**: Wrap Ollama's `chatNonStreaming` as the `StreamingChatFn` (ignoring the unused `abortTrigger` parameter). OpenAI provider continues using `chatStream`.

## Test plan
- [x] `dart analyze --fatal-infos` — 0 issues
- [x] `dart test` — 16/16 pass
- [x] Smoke tested: text-only response (no crash)
- [x] Smoke tested: tool call with `execute_python` + Monty — blackboard write/dump works
- [x] Verified via curl that Ollama streaming omits `call_id`, non-streaming includes it