### PR TITLE
fix(completions): remove system prompt fallback from oracle pathway

### DIFF
--- a/packages/soliplex_completions/lib/src/open_responses_llm_provider.dart
+++ b/packages/soliplex_completions/lib/src/open_responses_llm_provider.dart
@@ -222,7 +222,7 @@ class OpenResponsesLlmProvider implements LlmProvider {
     final request = or.CreateResponseRequest(
       model: model,
       input: input,
-      instructions: systemPrompt ?? this.systemPrompt,
+      instructions: systemPrompt,
       maxOutputTokens: maxTokens,
     );
 
@@ -250,7 +250,7 @@ class OpenResponsesLlmProvider implements LlmProvider {
     final request = or.CreateResponseRequest(
       model: model,
       input: input,
-      instructions: systemPrompt ?? this.systemPrompt,
+      instructions: systemPrompt,
       maxOutputTokens: maxTokens,
     );
 
@@ -309,9 +309,11 @@ class OpenResponsesLlmProvider implements LlmProvider {
     return switch (event) {
       or.OutputTextDeltaEvent(:final delta) => LlmTextDelta(delta),
       or.OutputTextDoneEvent(:final text) => LlmTextDone(text),
-      or.FunctionCallArgumentsDeltaEvent(:final callId, :final delta) =>
+      or.FunctionCallArgumentsDeltaEvent(:final callId, :final delta)
+          when callId != null =>
         LlmToolCallArgsDelta(callId: callId, delta: delta),
-      or.FunctionCallArgumentsDoneEvent(:final callId, :final arguments) =>
+      or.FunctionCallArgumentsDoneEvent(:final callId, :final arguments)
+          when callId != null =>
         LlmToolCallDone(callId: callId, arguments: arguments),
       or.OutputItemAddedEvent(:final item) => switch (item) {
           or.FunctionCallOutputItemResponse(:final callId, :final name) =>

--- a/packages/soliplex_completions/test/src/open_responses_llm_provider_test.dart
+++ b/packages/soliplex_completions/test/src/open_responses_llm_provider_test.dart
@@ -13,9 +13,11 @@ void main() {
       return switch (event) {
         or.OutputTextDeltaEvent(:final delta) => LlmTextDelta(delta),
         or.OutputTextDoneEvent(:final text) => LlmTextDone(text),
-        or.FunctionCallArgumentsDeltaEvent(:final callId, :final delta) =>
+        or.FunctionCallArgumentsDeltaEvent(:final callId, :final delta)
+            when callId != null =>
           LlmToolCallArgsDelta(callId: callId, delta: delta),
-        or.FunctionCallArgumentsDoneEvent(:final callId, :final arguments) =>
+        or.FunctionCallArgumentsDoneEvent(:final callId, :final arguments)
+            when callId != null =>
           LlmToolCallDone(callId: callId, arguments: arguments),
         or.OutputItemAddedEvent(:final item) => switch (item) {
             or.FunctionCallOutputItemResponse(:final callId, :final name) =>


### PR DESCRIPTION
## Summary
- Remove `?? this.systemPrompt` fallback from `complete()` method in `OpenResponsesLlmProvider`
- The fallback leaked the IoI code-generation system prompt into every `oracle()` call, causing 85% oracle confusion
- Fix nullable `callId` analysis errors in streaming event mapper with `when callId != null` guards

## Root Cause
The `complete()` method (used by oracle calls via `llm_complete`) fell back to `this.systemPrompt` when no explicit system prompt was passed. Since the provider is constructed with the IoI system prompt ("Your ONLY job is to write Python orchestration programs"), every oracle call received that instruction — causing the oracle to respond with code fragments instead of natural language answers.

The same `?? this.systemPrompt` fallback in `chatStream()`, `chatNonStreaming()`, and `chat()` is correct — those are agent-level calls where the default system prompt IS desired.

## Impact (from IoI experiment data)
- **Before fix:** 6.4% TRUE_COMPLETE across 110 baseline runs, 85% average oracle confusion
- **After fix:** 58.2% TRUE_COMPLETE across 55 oracle-fix runs, **0% oracle confusion**
- **incremental-state task:** 0% → 100% completion (the headline result)
- **gatekeeper task:** 100% Clever Hans (fallback code) → 100% genuine completion

## Test plan
- [x] `dart analyze --fatal-infos` passes on `soliplex_completions`
- [x] Existing unit tests pass (streaming event mapping, factory constructors)
- [x] 55 IoI experiment runs validate the fix eliminates oracle confusion
- [ ] Note: pre-commit hook fails on pre-existing `soliplex_interpreter_monty` errors (missing `dart_monty_bridge` dep) — unrelated to this change