### PR TITLE
fix(agent,cli): configurable maxToolDepth + untruncated trace output

### DIFF
--- a/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
+++ b/packages/soliplex_agent/lib/src/orchestration/run_orchestrator.dart
@@ -68,15 +68,19 @@ class RunOrchestrator {
     required AgentLlmProvider llmProvider,
     required ToolRegistry toolRegistry,
     required Logger logger,
+    int maxToolDepth = defaultMaxToolDepth,
   })  : _llmProvider = llmProvider,
         _toolRegistry = toolRegistry,
-        _logger = logger;
+        _logger = logger,
+        _maxToolDepth = maxToolDepth;
+
+  /// Default maximum tool-call depth before the orchestrator aborts.
+  static const defaultMaxToolDepth = 10;
 
   final AgentLlmProvider _llmProvider;
   final ToolRegistry _toolRegistry;
   final Logger _logger;
-
-  static const _maxToolDepth = 10;
+  final int _maxToolDepth;
 
   final StreamController<RunState> _controller =
       StreamController<RunState>.broadcast();

--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -801,8 +801,7 @@ void _traceExecutionEvent(ExecutionEvent event) {
     case ClientToolExecuting(:final toolName, :final toolCallId):
       stderr.writeln('[TOOL] Executing $toolName  id=${_short(toolCallId)}');
     case ClientToolCompleted(:final toolCallId, :final result, :final status):
-      final preview =
-          result.length > 200 ? '${result.substring(0, 200)}...' : result;
+      final preview = result;
       stderr.writeln(
         '[TOOL] Completed ${_short(toolCallId)}  '
         'status=$status  result=$preview',


### PR DESCRIPTION
## Summary
- Make `RunOrchestrator.maxToolDepth` a constructor parameter (default 10)
- Remove 200-char truncation on tool result trace output in CLI

## Changes
- **soliplex_agent**: `RunOrchestrator` gains optional `maxToolDepth` param with `defaultMaxToolDepth = 10` constant. All existing callers unaffected (use default).
- **soliplex_cli**: `_traceExecutionEvent` no longer truncates `ClientToolCompleted.result` to 200 chars. Full output needed for IoI experiment analysis.

## Test plan
- [x] `dart analyze --fatal-infos` passes on both packages
- [x] No existing callers break (all use named params, new param has default)