### PR TITLE
refactor(deps): migrate to dart_monty 0.9 pure Dart API

### DIFF
--- a/packages/soliplex_cli/lib/src/cli_runner.dart
+++ b/packages/soliplex_cli/lib/src/cli_runner.dart
@@ -2,9 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:dart_monty_ffi/dart_monty_ffi.dart';
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
-    show MontyPlatform;
+import 'package:dart_monty/dart_monty.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_cli/src/client_factory.dart';
 import 'package:soliplex_cli/src/result_printer.dart';
@@ -279,10 +277,6 @@ Future<void> _runSession(ArgResults parsed) async {
   // reference when sessions are spawned (not at construction time).
   AgentApi? agentApi;
   if (montyEnabled) {
-    if (wasmMode) {
-      // Retain global singleton for simulated WASM (single bridge).
-      MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
-    }
     final hostApi = FakeHostApi(
       invokeHandler: (name, args) async {
         if (name == 'log') {
@@ -296,8 +290,10 @@ Future<void> _runSession(ArgResults parsed) async {
     );
     final blackboardApi = DirectBlackboardApi();
     final fetchClient = DartHttpClient();
-    final MontyPlatformFactory? montyPlatformFactory =
-        wasmMode ? null : () async => MontyFfi(bindings: NativeBindingsFfi());
+    // WASM mode shares a single platform (simulates single-bridge constraint).
+    final sharedPlatform = wasmMode ? Monty() : null;
+    final MontyPlatformFactory montyPlatformFactory =
+        wasmMode ? () async => sharedPlatform! : () async => Monty();
     extensionFactory = () async {
       final factory = createMontyScriptEnvironmentFactory(
         hostApi: hostApi,

--- a/packages/soliplex_cli/pubspec.yaml
+++ b/packages/soliplex_cli/pubspec.yaml
@@ -8,16 +8,10 @@ environment:
 
 dependencies:
   args: ^2.4.0
-  dart_monty_ffi:
+  dart_monty:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
-      path: packages/dart_monty_ffi
-  dart_monty_platform_interface:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_platform_interface
   soliplex_agent:
     path: ../soliplex_agent
   soliplex_client:
@@ -36,15 +30,28 @@ dependencies:
     git:
       url: https://github.com/runyaga/struct_log.git
 
-dev_dependencies:
-  mocktail: ^1.0.0
-  test: ^1.24.0
-  very_good_analysis: ^10.0.0
-
 dependency_overrides:
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
   dart_monty_platform_interface:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
+
+dev_dependencies:
+  mocktail: ^1.0.0
+  test: ^1.24.0
+  very_good_analysis: ^10.0.0
 

--- a/packages/soliplex_interpreter_monty/example/example.dart
+++ b/packages/soliplex_interpreter_monty/example/example.dart
@@ -9,8 +9,7 @@ void main() {
   // final bridge = DefaultMontyBridge(platform: myMontyPlatform);
 
   // 2. Optionally register host functions so Python can call Dart.
-  // final registry = HostFunctionRegistry();
-  // registry.registerOnto(bridge);
+  // bridge.register(myHostFunction);
 
   // 3. Execute Python code and listen for bridge events.
   // final events = bridge.execute('print("Hello from Monty!")');

--- a/packages/soliplex_interpreter_monty/lib/soliplex_interpreter_monty.dart
+++ b/packages/soliplex_interpreter_monty/lib/soliplex_interpreter_monty.dart
@@ -24,7 +24,6 @@ export 'package:dart_monty_bridge/dart_monty_bridge.dart'
         EventLoopBridge,
         HostFunction,
         HostFunctionHandler,
-        HostFunctionRegistry,
         HostFunctionSchema,
         HostParam,
         HostParamType,

--- a/packages/soliplex_interpreter_monty/lib/src/console_event.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/console_event.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:meta/meta.dart';
 import 'package:soliplex_interpreter_monty/src/execution_result.dart';
 

--- a/packages/soliplex_interpreter_monty/lib/src/execution_result.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/execution_result.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:meta/meta.dart';
 
 /// The result of a completed Python execution.

--- a/packages/soliplex_interpreter_monty/lib/src/monty_execution_service.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/monty_execution_service.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:soliplex_interpreter_monty/src/console_event.dart';
 import 'package:soliplex_interpreter_monty/src/execution_result.dart';
 
@@ -34,7 +34,7 @@ class MontyExecutionService {
   bool _isExecuting = false;
   bool _isDisposed = false;
 
-  MontyPlatform get _platform => _explicitPlatform ?? MontyPlatform.instance;
+  MontyPlatform get _platform => _explicitPlatform ?? Monty();
 
   /// Whether an execution is currently in progress.
   bool get isExecuting => _isExecuting;

--- a/packages/soliplex_interpreter_monty/lib/src/monty_limits_defaults.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/monty_limits_defaults.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 
 /// Safe default resource limits for Monty execution contexts.
 abstract final class MontyLimitsDefaults {

--- a/packages/soliplex_interpreter_monty/lib/src/schema_executor.dart
+++ b/packages/soliplex_interpreter_monty/lib/src/schema_executor.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 
 /// Converts a Dart value to a Python literal string.
 String _toPythonLiteral(Object? value) {
@@ -35,7 +35,7 @@ class SchemaExecutor {
   final MontyPlatform? _explicitPlatform;
   final Map<String, String> _schemas = {};
 
-  MontyPlatform get _platform => _explicitPlatform ?? MontyPlatform.instance;
+  MontyPlatform get _platform => _explicitPlatform ?? Monty();
 
   /// Names of all loaded schemas.
   Iterable<String> get schemaNames => _schemas.keys;

--- a/packages/soliplex_interpreter_monty/pubspec.yaml
+++ b/packages/soliplex_interpreter_monty/pubspec.yaml
@@ -7,26 +7,43 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
   dart_monty_bridge:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_bridge
-  dart_monty_platform_interface:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_platform_interface
   meta: ^1.11.0
 
 dependency_overrides:
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
   dart_monty_platform_interface:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
 
 dev_dependencies:
+  dart_monty_platform_interface:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_platform_interface
   mocktail: ^1.0.4
   test: ^1.24.0
   very_good_analysis: ^10.0.0

--- a/packages/soliplex_interpreter_monty/test/integration/layer0_pure_execution_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer0_pure_execution_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_interpreter_monty/test/integration/layer1_introspection_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer1_introspection_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty_bridge/dart_monty_bridge.dart'
+    show buildIntrospectionFunctions;
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';
@@ -15,20 +17,26 @@ void main() {
       setUp(() {
         mock = MockMontyPlatform();
         bridge = DefaultMontyBridge(platform: mock, useFutures: false);
-        (HostFunctionRegistry()
-              ..addCategory('finance', [
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'get_price',
-                    description: 'Get stock price by symbol.',
-                    params: [
-                      HostParam(name: 'symbol', type: HostParamType.string),
-                    ],
-                  ),
-                  handler: (args) async => 42.5,
-                ),
-              ]))
-            .registerAllOnto(bridge);
+
+        const getPriceSchema = HostFunctionSchema(
+          name: 'get_price',
+          description: 'Get stock price by symbol.',
+          params: [
+            HostParam(name: 'symbol', type: HostParamType.string),
+          ],
+        );
+
+        bridge.register(
+          HostFunction(
+            schema: getPriceSchema,
+            handler: (args) async => 42.5,
+          ),
+        );
+
+        // Register introspection builtins (list_functions, help).
+        buildIntrospectionFunctions({
+          'finance': [getPriceSchema],
+        }).forEach(bridge.register);
       });
 
       tearDown(() => bridge.dispose());

--- a/packages/soliplex_interpreter_monty/test/integration/layer1_tool_calls_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer1_tool_calls_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_interpreter_monty/test/integration/layer2_agentic_pipeline_test.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/layer2_agentic_pipeline_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';
@@ -15,35 +15,34 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
-
-        (HostFunctionRegistry()
-              ..addCategory('research', [
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'search',
-                    description: 'Search for information.',
-                    params: [
-                      HostParam(name: 'query', type: HostParamType.string),
-                    ],
-                  ),
-                  handler: (args) async =>
-                      'Quantum computing made major breakthroughs in 2026 '
-                      'with error correction achieving 99.9% fidelity.',
-                ),
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'summarize',
-                    description: 'Summarize text to max_words.',
-                    params: [
-                      HostParam(name: 'text', type: HostParamType.string),
-                      HostParam(name: 'max_words', type: HostParamType.integer),
-                    ],
-                  ),
-                  handler: (args) async => 'Quantum computing: 99.9% fidelity.',
-                ),
-              ]))
-            .registerAllOnto(bridge);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'search',
+                description: 'Search for information.',
+                params: [
+                  HostParam(name: 'query', type: HostParamType.string),
+                ],
+              ),
+              handler: (args) async =>
+                  'Quantum computing made major breakthroughs in 2026 '
+                  'with error correction achieving 99.9% fidelity.',
+            ),
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'summarize',
+                description: 'Summarize text to max_words.',
+                params: [
+                  HostParam(name: 'text', type: HostParamType.string),
+                  HostParam(name: 'max_words', type: HostParamType.integer),
+                ],
+              ),
+              handler: (args) async => 'Quantum computing: 99.9% fidelity.',
+            ),
+          );
       });
 
       tearDown(() => bridge.dispose());
@@ -120,41 +119,40 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
-
-        (HostFunctionRegistry()
-              ..addCategory('data', [
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'fetch_sales',
-                    description: 'Fetch sales data for a region.',
-                    params: [
-                      HostParam(name: 'region', type: HostParamType.string),
-                    ],
-                  ),
-                  handler: (args) async => [
-                    {'month': 'Jan', 'amount': 1200},
-                    {'month': 'Jan', 'amount': 800},
-                    {'month': 'Feb', 'amount': 1500},
-                  ],
-                ),
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'chart_bar',
-                    description: 'Render a bar chart.',
-                    params: [
-                      HostParam(name: 'title', type: HostParamType.string),
-                      HostParam(name: 'data', type: HostParamType.list),
-                    ],
-                  ),
-                  handler: (args) async => {
-                    'chart_id': 'chart_001',
-                    'type': 'bar',
-                    'title': args['title'],
-                  },
-                ),
-              ]))
-            .registerAllOnto(bridge);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'fetch_sales',
+                description: 'Fetch sales data for a region.',
+                params: [
+                  HostParam(name: 'region', type: HostParamType.string),
+                ],
+              ),
+              handler: (args) async => [
+                {'month': 'Jan', 'amount': 1200},
+                {'month': 'Jan', 'amount': 800},
+                {'month': 'Feb', 'amount': 1500},
+              ],
+            ),
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'chart_bar',
+                description: 'Render a bar chart.',
+                params: [
+                  HostParam(name: 'title', type: HostParamType.string),
+                  HostParam(name: 'data', type: HostParamType.list),
+                ],
+              ),
+              handler: (args) async => {
+                'chart_id': 'chart_001',
+                'type': 'bar',
+                'title': args['title'],
+              },
+            ),
+          );
       });
 
       tearDown(() => bridge.dispose());
@@ -227,33 +225,32 @@ void main() {
 
       setUp(() {
         mock = MockMontyPlatform();
-        bridge = DefaultMontyBridge(platform: mock, useFutures: false);
-
-        (HostFunctionRegistry()
-              ..addCategory('storage', [
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'get_data',
-                    description: 'Fetch data by key.',
-                    params: [
-                      HostParam(name: 'key', type: HostParamType.string),
-                    ],
-                  ),
-                  handler: (args) async => {'theme': 'dark', 'lang': 'en'},
-                ),
-                HostFunction(
-                  schema: const HostFunctionSchema(
-                    name: 'store_result',
-                    description: 'Store a key-value result.',
-                    params: [
-                      HostParam(name: 'key', type: HostParamType.string),
-                      HostParam(name: 'value', type: HostParamType.string),
-                    ],
-                  ),
-                  handler: (args) async => true,
-                ),
-              ]))
-            .registerAllOnto(bridge);
+        bridge = DefaultMontyBridge(platform: mock, useFutures: false)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'get_data',
+                description: 'Fetch data by key.',
+                params: [
+                  HostParam(name: 'key', type: HostParamType.string),
+                ],
+              ),
+              handler: (args) async => {'theme': 'dark', 'lang': 'en'},
+            ),
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'store_result',
+                description: 'Store a key-value result.',
+                params: [
+                  HostParam(name: 'key', type: HostParamType.string),
+                  HostParam(name: 'value', type: HostParamType.string),
+                ],
+              ),
+              handler: (args) async => true,
+            ),
+          );
       });
 
       tearDown(() => bridge.dispose());

--- a/packages/soliplex_interpreter_monty/test/integration/room_fixture.dart
+++ b/packages/soliplex_interpreter_monty/test/integration/room_fixture.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_interpreter_monty/test/src/console_event_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/console_event_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_interpreter_monty/test/src/execution_result_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/execution_result_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_interpreter_monty/test/src/monty_execution_service_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/monty_execution_service_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_interpreter_monty/test/src/schema_executor_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/schema_executor_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:soliplex_interpreter_monty/src/schema_executor.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_interpreter_monty/test/src/schema_spike_test.dart
+++ b/packages/soliplex_interpreter_monty/test/src/schema_spike_test.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_scripting/lib/src/monty_script_environment.dart
+++ b/packages/soliplex_scripting/lib/src/monty_script_environment.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:ag_ui/ag_ui.dart' show Tool;
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
-    show MontyPlatform;
+import 'package:dart_monty/dart_monty.dart' show MontyPlatform;
 import 'package:soliplex_agent/soliplex_agent.dart'
     show ClientTool, ScriptEnvironment;
 import 'package:soliplex_client/soliplex_client.dart' show ToolCallInfo;

--- a/packages/soliplex_scripting/lib/src/monty_script_environment_factory.dart
+++ b/packages/soliplex_scripting/lib/src/monty_script_environment_factory.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart'
-    show MontyLimits, MontyPlatform;
+import 'package:dart_monty/dart_monty.dart' show MontyLimits, MontyPlatform;
 import 'package:soliplex_agent/soliplex_agent.dart'
     show AgentApi, BlackboardApi, FormApi, HostApi, ScriptEnvironmentFactory;
 import 'package:soliplex_client/soliplex_client.dart' show SoliplexHttpClient;
@@ -33,13 +32,13 @@ typedef MontyPlatformFactory = Future<MontyPlatform> Function();
 /// When [platformFactory] is provided, each session gets its own
 /// [MontyPlatform] instance, enabling concurrent Monty execution
 /// across sessions (e.g. parent + child agents). Without it, the
-/// bridge falls back to the global [MontyPlatform.instance] singleton.
+/// bridge falls back to the default `Monty()` constructor.
 ///
 /// ```dart
 /// final factory = createMontyScriptEnvironmentFactory(
 ///   hostApi: myHostApi,
 ///   agentApi: myAgentApi,
-///   platformFactory: () async => MontyFfi(bindings: NativeBindingsFfi()),
+///   platformFactory: () async => Monty(),
 /// );
 /// final runtime = AgentRuntime(
 ///   // ...

--- a/packages/soliplex_scripting/lib/src/plugin_registry.dart
+++ b/packages/soliplex_scripting/lib/src/plugin_registry.dart
@@ -1,5 +1,7 @@
 import 'dart:collection';
 
+import 'package:dart_monty_bridge/dart_monty_bridge.dart'
+    show buildIntrospectionFunctions;
 import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
 
 /// Mixin for plugins whose function names predate the `namespace_` prefix
@@ -59,14 +61,28 @@ class PluginRegistry {
     MontyBridge bridge, {
     List<HostFunction>? extraFunctions,
   }) async {
-    final hostRegistry = HostFunctionRegistry();
+    final schemasByCategory = <String, List<HostFunctionSchema>>{};
+
     for (final plugin in _plugins) {
-      hostRegistry.addCategory(plugin.namespace, plugin.functions);
+      final schemas = <HostFunctionSchema>[];
+      for (final fn in plugin.functions) {
+        bridge.register(fn);
+        schemas.add(fn.schema);
+      }
+      schemasByCategory[plugin.namespace] = schemas;
     }
     if (extraFunctions != null && extraFunctions.isNotEmpty) {
-      hostRegistry.addCategory('extra', extraFunctions);
+      final schemas = <HostFunctionSchema>[];
+      for (final fn in extraFunctions) {
+        bridge.register(fn);
+        schemas.add(fn.schema);
+      }
+      schemasByCategory['extra'] = schemas;
     }
-    hostRegistry.registerAllOnto(bridge);
+
+    // Register introspection builtins (list_functions, help).
+    buildIntrospectionFunctions(schemasByCategory).forEach(bridge.register);
+
     for (final plugin in _plugins) {
       await plugin.onRegister(bridge);
     }

--- a/packages/soliplex_scripting/pubspec.yaml
+++ b/packages/soliplex_scripting/pubspec.yaml
@@ -11,11 +11,15 @@ dependencies:
     git:
       url: https://github.com/soliplex/ag-ui.git
       path: sdks/community/dart
-  dart_monty_platform_interface:
+  dart_monty:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
-      path: packages/dart_monty_platform_interface
+  dart_monty_bridge:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_bridge
   meta: ^1.11.0
   soliplex_agent:
     path: ../soliplex_agent
@@ -30,11 +34,24 @@ dependencies:
       url: https://github.com/runyaga/struct_log.git
 
 dependency_overrides:
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
   dart_monty_platform_interface:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:dart_monty_ffi/dart_monty_ffi.dart';
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty/dart_monty.dart';
 import 'package:meta/meta.dart';
 import 'package:nocterm/nocterm.dart';
 import 'package:signals_core/signals_core.dart';
@@ -490,7 +489,6 @@ Future<void> listRooms({required String serverUrl}) async {
     );
   }
 
-  MontyPlatform.instance = MontyFfi(bindings: NativeBindingsFfi());
   final blackboardApi = DirectBlackboardApi();
   AgentApi? agentApi;
 
@@ -510,7 +508,7 @@ Future<void> listRooms({required String serverUrl}) async {
         limits: limits,
         executionTimeout: timeout,
         agentTimeout: timeout,
-        platformFactory: () async => MontyFfi(bindings: NativeBindingsFfi()),
+        platformFactory: () async => Monty(),
         llmCompleter: provider?.complete,
         llmChatCompleter: provider != null
             ? (messages, {systemPrompt, maxTokens}) => provider.chat(

--- a/packages/soliplex_tui/pubspec.yaml
+++ b/packages/soliplex_tui/pubspec.yaml
@@ -8,16 +8,10 @@ environment:
 
 dependencies:
   args: ^2.5.0
-  dart_monty_ffi:
+  dart_monty:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
-      path: packages/dart_monty_ffi
-  dart_monty_platform_interface:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_platform_interface
   glob: ^2.1.0
   meta: ^1.12.0
   nocterm: ^0.5.0
@@ -42,15 +36,28 @@ dependencies:
     git:
       url: https://github.com/runyaga/struct_log.git
 
-dev_dependencies:
-  mocktail: ^1.0.0
-  test: ^1.25.0
-  very_good_analysis: ^10.0.0
-
 dependency_overrides:
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
   dart_monty_platform_interface:
     git:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_platform_interface
+  dart_monty_wasm:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_wasm
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
+
+dev_dependencies:
+  mocktail: ^1.0.0
+  test: ^1.25.0
+  very_good_analysis: ^10.0.0
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,6 +34,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
+  anthropic_sdk_dart:
+    dependency: transitive
+    description:
+      name: anthropic_sdk_dart
+      sha256: "6b847a3f61d6ca39bb8a7479f294e5e7b3d1d216449dbaed3b10ff483b0097c3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   archive:
     dependency: transitive
     description:
@@ -186,6 +194,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dart_monty:
+    dependency: transitive
+    description:
+      path: "."
+      ref: main
+      resolved-ref: "70f2414294f1006ccf5f02e65694bcaa5314b6fd"
+      url: "https://github.com/runyaga/dart_monty.git"
+    source: git
+    version: "0.9.0"
   dart_monty_bridge:
     dependency: transitive
     description:
@@ -204,17 +221,8 @@ packages:
       url: "https://github.com/runyaga/dart_monty.git"
     source: git
     version: "0.7.0"
-  dart_monty_native:
-    dependency: "direct main"
-    description:
-      path: "packages/dart_monty_native"
-      ref: main
-      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
-      url: "https://github.com/runyaga/dart_monty.git"
-    source: git
-    version: "0.7.0"
   dart_monty_platform_interface:
-    dependency: "direct main"
+    dependency: "direct overridden"
     description:
       path: "packages/dart_monty_platform_interface"
       ref: main
@@ -223,18 +231,9 @@ packages:
     source: git
     version: "0.6.1"
   dart_monty_wasm:
-    dependency: "direct main"
+    dependency: "direct overridden"
     description:
       path: "packages/dart_monty_wasm"
-      ref: main
-      resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
-      url: "https://github.com/runyaga/dart_monty.git"
-    source: git
-    version: "0.6.1"
-  dart_monty_web:
-    dependency: "direct main"
-    description:
-      path: "packages/dart_monty_web"
       ref: main
       resolved-ref: b3ac889cbcb658ab5c4f54131f3bfcc26a3324ff
       url: "https://github.com/runyaga/dart_monty.git"
@@ -444,6 +443,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -678,6 +685,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  ollama_dart:
+    dependency: transitive
+    description:
+      name: ollama_dart
+      sha256: "55a45e381f3cf24791df510e287f353e776d376f556d34ba49b09bc918eee319"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
+  open_responses:
+    dependency: transitive
+    description:
+      name: open_responses
+      sha256: "36fddff2706c9eb1b1766a97c02c2fe5db2b69ad0781532ec0fccc26b0f738f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
+  openai_dart:
+    dependency: transitive
+    description:
+      name: openai_dart
+      sha256: "4731f94ea9a09cd9e92333debcfb87efda2764718e506538206df9f540e9ab60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   package_config:
     dependency: transitive
     description:
@@ -976,6 +1007,13 @@ packages:
       relative: true
     source: path
     version: "1.0.0-dev"
+  soliplex_completions:
+    dependency: transitive
+    description:
+      path: "packages/soliplex_completions"
+      relative: true
+    source: path
+    version: "0.1.0"
   soliplex_dataframe:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,26 +12,6 @@ environment:
 dependencies:
   connectivity_plus: ^7.0.0
   cupertino_icons: ^1.0.8
-  dart_monty_native:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_native
-  dart_monty_platform_interface:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_platform_interface
-  dart_monty_wasm:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_wasm
-  dart_monty_web:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_web
   device_info_plus: ^12.3.0
   fl_chart: ^0.70.2
   flutter:
@@ -77,6 +57,11 @@ dependencies:
   web: ^1.1.1
 
 dependency_overrides:
+  dart_monty_ffi:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+      path: packages/dart_monty_ffi
   dart_monty_platform_interface:
     git:
       url: https://github.com/runyaga/dart_monty.git
@@ -87,11 +72,6 @@ dependency_overrides:
       url: https://github.com/runyaga/dart_monty.git
       ref: main
       path: packages/dart_monty_wasm
-  dart_monty_ffi:
-    git:
-      url: https://github.com/runyaga/dart_monty.git
-      ref: main
-      path: packages/dart_monty_ffi
 
 dev_dependencies:
   fake_async: ^1.3.3


### PR DESCRIPTION
## Summary
- Replace direct `dart_monty_platform_interface` / `dart_monty_ffi` deps with unified `dart_monty` package across all consuming packages
- Monty now flows transitively through `soliplex_interpreter_monty` — root pubspec no longer lists sub-packages
- Migrate from removed `HostFunctionRegistry` (dart_monty_bridge 0.3.0 breaking change) to direct `bridge.register()` + `buildIntrospectionFunctions()`
- Remove all deprecated `MontyPlatform.instance` usage — replaced with `Monty()` constructor

## Changes
- **6 pubspec.yaml files**: Updated dependency declarations, sorted `dependency_overrides` alphabetically, added `dart_monty_bridge` as explicit dep where needed
- **soliplex_interpreter_monty**: All imports migrated, `HostFunctionRegistry` removed from barrel export, deprecated `MontyPlatform.instance` → `Monty()`
- **soliplex_scripting**: `PluginRegistry.attachTo()` rewritten without `HostFunctionRegistry`, doc comments updated
- **soliplex_cli**: `MontyFfi(bindings: NativeBindingsFfi())` → `Monty()`, WASM mode uses shared platform instance instead of deprecated singleton
- **soliplex_tui**: Same import migration, removed unused `MontyPlatform.instance` setter
- **Integration tests**: Migrated from `HostFunctionRegistry` to direct `bridge.register()` with introspection builtins

## Test plan
- [x] `soliplex_interpreter_monty`: 71 tests passing, 0 analysis issues
- [x] `soliplex_scripting`: 203 tests passing, 0 analysis issues
- [x] `soliplex_cli`: 0 analysis issues
- [x] `soliplex_tui`: 0 analysis issues
- [x] Root `flutter pub get` resolves cleanly
- [x] Pre-commit hooks: format, analyze, secrets — all passed