### PR TITLE
refactor(agent): remove mega-barrel re-export and fix session memory leak

### DIFF
--- a/packages/soliplex_agent/lib/soliplex_agent.dart
+++ b/packages/soliplex_agent/lib/soliplex_agent.dart
@@ -5,38 +5,8 @@
 /// `soliplex_logging` — no Flutter imports allowed.
 library;
 
-// Re-export signal types for consumers.
+// Re-export signal types used in public API (sessions expose ReadonlySignal).
 export 'package:signals_core/signals_core.dart' show ReadonlySignal, Signal;
-// Re-export domain types and AG-UI events. Consumers who need HTTP plumbing
-// (SoliplexApi, AgUiStreamClient, DartHttpClient, etc.) import soliplex_client
-// directly.
-export 'package:soliplex_client/soliplex_client.dart'
-    hide
-        AuthenticatedHttpClient,
-        DartHttpClient,
-        HttpErrorEvent,
-        HttpEvent,
-        HttpObserver,
-        HttpRequestEvent,
-        HttpResponse,
-        HttpResponseEvent,
-        HttpStreamEndEvent,
-        HttpStreamStartEvent,
-        HttpTransport,
-        ObservableHttpClient,
-        OidcDiscoveryDocument,
-        RefreshingHttpClient,
-        SoliplexApi,
-        SoliplexHttpClient,
-        TokenRefreshFailure,
-        TokenRefreshResult,
-        TokenRefreshService,
-        TokenRefreshSuccess,
-        TokenRefresher,
-        UrlBuilder,
-        convertToAgui,
-        defaultHttpTimeout,
-        fetchAuthProviders;
 
 // ── Host API ──
 export 'src/host/agent_api.dart';

--- a/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_runtime.dart
@@ -155,11 +155,10 @@ class AgentRuntime {
       );
     } on Object {
       parent?.removeChild(session);
-      _removeSession(session);
       if (ephemeral) {
         await _deleteThreadSafe(key);
       }
-      session.dispose();
+      session.dispose(); // onDispose callback handles _removeSession.
       rethrow;
     }
     _scheduleCompletion(session, timeout, autoDispose: autoDispose);
@@ -309,6 +308,7 @@ class AgentRuntime {
       extensions: extensions,
       uiDelegate: _uiDelegate,
       logger: _logger,
+      onDispose: _removeSession,
     );
   }
 
@@ -383,8 +383,7 @@ class AgentRuntime {
     if (session.ephemeral) {
       await _deleteThreadSafe(session.threadKey);
     }
-    session.dispose();
-    _removeSession(session);
+    session.dispose(); // onDispose callback handles _removeSession.
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/soliplex_agent/lib/src/runtime/agent_session.dart
+++ b/packages/soliplex_agent/lib/src/runtime/agent_session.dart
@@ -44,12 +44,14 @@ class AgentSession implements ToolExecutionContext {
     required Logger logger,
     List<SessionExtension> extensions = const [],
     AgentUiDelegate? uiDelegate,
+    void Function(AgentSession)? onDispose,
   })  : _runtime = runtime,
         _orchestrator = orchestrator,
         _toolRegistry = toolRegistry,
         _extensions = extensions,
         _uiDelegate = uiDelegate,
         _logger = logger,
+        _onDispose = onDispose,
         id = '${threadKey.threadId}-'
             '${DateTime.now().microsecondsSinceEpoch}';
 
@@ -71,6 +73,7 @@ class AgentSession implements ToolExecutionContext {
   final List<SessionExtension> _extensions;
   final AgentUiDelegate? _uiDelegate;
   final Logger _logger;
+  final void Function(AgentSession)? _onDispose;
 
   static const _toolTimeout = Duration(seconds: 60);
 
@@ -285,6 +288,7 @@ class AgentSession implements ToolExecutionContext {
     _runStateSignal.dispose();
     _sessionStateSignal.dispose();
     _executionEventSignal.dispose();
+    _onDispose?.call(this);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
+++ b/packages/soliplex_agent/test/helpers/fake_tool_execution_context.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// Test double for [ToolExecutionContext].
 ///

--- a/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
+++ b/packages/soliplex_agent/test/host/runtime_agent_api_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/integration/helpers/integration_harness.dart
+++ b/packages/soliplex_agent/test/integration/helpers/integration_harness.dart
@@ -1,13 +1,7 @@
 import 'dart:io';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show
-        AgUiStreamClient,
-        DartHttpClient,
-        HttpTransport,
-        SoliplexApi,
-        UrlBuilder;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/integration/verbose_agui_test.dart
+++ b/packages/soliplex_agent/test/integration/verbose_agui_test.dart
@@ -5,16 +5,7 @@ library;
 import 'dart:io';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show
-        DartHttpClient,
-        HttpErrorEvent,
-        HttpObserver,
-        HttpRequestEvent,
-        HttpResponseEvent,
-        HttpStreamEndEvent,
-        HttpStreamStartEvent,
-        ObservableHttpClient;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/chat_fn_llm_provider_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
+++ b/packages/soliplex_agent/test/orchestration/error_classifier_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/soliplex_agent/test/orchestration/execution_event_test.dart
+++ b/packages/soliplex_agent/test/orchestration/execution_event_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_orchestrator_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/orchestration/run_state_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_state_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 const ThreadKey _key = (

--- a/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
+++ b/packages/soliplex_agent/test/orchestration/run_to_completion_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
+++ b/packages/soliplex_agent/test/orchestration/streaming_llm_provider_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_completions/soliplex_completions.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/run/m7_room_integration_test.dart
+++ b/packages/soliplex_agent/test/run/m7_room_integration_test.dart
@@ -7,6 +7,7 @@ library;
 import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 import '../integration/helpers/helpers.dart';

--- a/packages/soliplex_agent/test/run/run_orchestrator_integration_test.dart
+++ b/packages/soliplex_agent/test/run/run_orchestrator_integration_test.dart
@@ -4,6 +4,7 @@
 library;
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 import '../integration/helpers/helpers.dart';

--- a/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_signal_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_runtime_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_signal_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/agent_session_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_session_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/agent_ui_delegate_test.dart
+++ b/packages/soliplex_agent/test/runtime/agent_ui_delegate_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
+++ b/packages/soliplex_agent/test/runtime/multi_server_runtime_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/runtime/server_connection_test.dart
+++ b/packages/soliplex_agent/test/runtime/server_connection_test.dart
@@ -1,7 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi, SoliplexHttpClient;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}

--- a/packages/soliplex_agent/test/runtime/server_registry_test.dart
+++ b/packages/soliplex_agent/test/runtime/server_registry_test.dart
@@ -1,7 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}

--- a/packages/soliplex_agent/test/runtime/session_children_test.dart
+++ b/packages/soliplex_agent/test/runtime/session_children_test.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:test/test.dart';
 

--- a/packages/soliplex_agent/test/scripting/script_environment_test.dart
+++ b/packages/soliplex_agent/test/scripting/script_environment_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 // ---------------------------------------------------------------------------

--- a/packages/soliplex_agent/test/tools/tool_registry_resolver_test.dart
+++ b/packages/soliplex_agent/test/tools/tool_registry_resolver_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_tool_execution_context.dart';

--- a/packages/soliplex_agent/test/tools/tool_registry_test.dart
+++ b/packages/soliplex_agent/test/tools/tool_registry_test.dart
@@ -1,4 +1,5 @@
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 import '../helpers/fake_tool_execution_context.dart';

--- a/packages/soliplex_cli/lib/src/tool_definitions.dart
+++ b/packages/soliplex_cli/lib/src/tool_definitions.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// All demo tools available in the CLI.
 ///

--- a/packages/soliplex_cli/test/src/tool_definitions_test.dart
+++ b/packages/soliplex_cli/test/src/tool_definitions_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
 import 'package:soliplex_cli/src/tool_definitions.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 /// Minimal [ToolExecutionContext] for test-only use.

--- a/packages/soliplex_tui/lib/src/app.dart
+++ b/packages/soliplex_tui/lib/src/app.dart
@@ -7,8 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:nocterm/nocterm.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show DartHttpClient, SoliplexApi, ThreadHistory, ToolCallInfo;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_completions/soliplex_completions.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_mcp/soliplex_mcp.dart';

--- a/packages/soliplex_tui/lib/src/chat_session_view.dart
+++ b/packages/soliplex_tui/lib/src/chat_session_view.dart
@@ -1,5 +1,6 @@
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_tui/src/loggers.dart';
 import 'package:soliplex_tui/src/services/tui_ui_delegate.dart';
 

--- a/packages/soliplex_tui/lib/src/components/chat_body.dart
+++ b/packages/soliplex_tui/lib/src/components/chat_body.dart
@@ -1,5 +1,6 @@
 import 'package:nocterm/nocterm.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 import 'package:soliplex_tui/src/components/message_item.dart';
 import 'package:soliplex_tui/src/signal_builder.dart';

--- a/packages/soliplex_tui/lib/src/components/chat_page.dart
+++ b/packages/soliplex_tui/lib/src/components/chat_page.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_tui/src/chat_session_view.dart';
 import 'package:soliplex_tui/src/components/chat_body.dart';

--- a/packages/soliplex_tui/lib/src/components/message_item.dart
+++ b/packages/soliplex_tui/lib/src/components/message_item.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// Renders a single chat message based on its subtype.
 class MessageItem extends StatelessComponent {

--- a/packages/soliplex_tui/lib/src/components/subagent_pane.dart
+++ b/packages/soliplex_tui/lib/src/components/subagent_pane.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_agent/soliplex_agent.dart' hide State;
+import 'package:soliplex_agent/soliplex_agent.dart';
 
 import 'package:soliplex_tui/src/signal_builder.dart';
 

--- a/packages/soliplex_tui/lib/src/components/tool_status_bar.dart
+++ b/packages/soliplex_tui/lib/src/components/tool_status_bar.dart
@@ -1,5 +1,5 @@
 import 'package:nocterm/nocterm.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// Status bar shown while client-side tools are executing.
 class ToolStatusBar extends StatelessComponent {

--- a/packages/soliplex_tui/lib/src/tool_definitions.dart
+++ b/packages/soliplex_tui/lib/src/tool_definitions.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// All demo tools available in the TUI.
 const _allDemoTools = [

--- a/packages/soliplex_tui/test/helpers/fake_event_stream.dart
+++ b/packages/soliplex_tui/test/helpers/fake_event_stream.dart
@@ -1,4 +1,4 @@
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 
 /// Builds a mock AG-UI event stream from a list of events.
 ///

--- a/packages/soliplex_tui/test/helpers/test_helpers.dart
+++ b/packages/soliplex_tui/test/helpers/test_helpers.dart
@@ -1,6 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart' show SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 
 class MockSoliplexApi extends Mock implements SoliplexApi {}
 

--- a/packages/soliplex_tui/test/integration/l1_headless_json_test.dart
+++ b/packages/soliplex_tui/test/integration/l1_headless_json_test.dart
@@ -3,8 +3,7 @@ import 'dart:convert';
 import 'package:mocktail/mocktail.dart';
 import 'package:signals_core/signals_core.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
-import 'package:soliplex_client/soliplex_client.dart'
-    show AgUiStreamClient, SoliplexApi;
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_logging/soliplex_logging.dart';
 import 'package:soliplex_tui/src/tool_definitions.dart';
 import 'package:test/test.dart';

--- a/packages/soliplex_tui/test/src/headless_test.dart
+++ b/packages/soliplex_tui/test/src/headless_test.dart
@@ -1,5 +1,5 @@
 import 'package:mocktail/mocktail.dart';
-import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:test/test.dart';
 
 import '../helpers/test_helpers.dart';

--- a/packages/soliplex_tui/test/src/mcp_tool_merge_test.dart
+++ b/packages/soliplex_tui/test/src/mcp_tool_merge_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_mcp/soliplex_mcp.dart';
 import 'package:soliplex_tui/src/app.dart' show mergeWithMcpTools;
 import 'package:test/test.dart';

--- a/packages/soliplex_tui/test/src/tool_definitions_test.dart
+++ b/packages/soliplex_tui/test/src/tool_definitions_test.dart
@@ -1,5 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:soliplex_agent/soliplex_agent.dart';
+import 'package:soliplex_client/soliplex_client.dart';
 import 'package:soliplex_tui/src/tool_definitions.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## Summary
- **Remove soliplex_client re-export from soliplex_agent barrel** — consumers now import soliplex_client explicitly, making dependency ownership clear and preventing cascading breaks from leaf dependency changes
- **Fix memory leak** where `autoDispose: false` sessions were never removed from `AgentRuntime._sessions` map — `AgentSession` now accepts an `onDispose` callback that auto-cleans the tracking map on any disposal path
- Gemini 3.1 Pro review caught double-removal in `_handleSessionComplete` and `spawn()` error path — both fixed

## Changes
- **soliplex_agent barrel** (`soliplex_agent.dart`): Removed 30-line `soliplex_client` re-export. Kept `signals_core` re-export (part of public API surface).
- **AgentSession**: Added `onDispose` callback parameter. `dispose()` invokes it after cleanup.
- **AgentRuntime**: Passes `_removeSession` as `onDispose` to session constructor. Removed now-redundant explicit `_removeSession` calls from `_handleSessionComplete` and `spawn()` error path.
- **Consumer files (8 lib + 22 test)**: Added explicit `import 'package:soliplex_client/soliplex_client.dart'` across agent, cli, tui packages. Removed stale `hide State` and widened `show` clauses.

## Test plan
- [x] `dart analyze --fatal-infos` — 0 issues across all 4 packages
- [x] `dart format` — 0 changes needed
- [x] `dart test` — 548 unit tests pass (agent: 394, cli: 16, tui: 69, scripting: 69)
- [x] Gemini 3.1 Pro review: 4x PASS, 2x WARNING (both fixed)

Addresses P0 fixes #1 and #2 from the [Soliplex API Audit](../soliplex-plans/api-audit-2026-03-10.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)