### PR TITLE
fix(agent): add @useResult to ToolRegistry builder methods

### DIFF
--- a/packages/soliplex_agent/lib/src/tools/tool_registry.dart
+++ b/packages/soliplex_agent/lib/src/tools/tool_registry.dart
@@ -81,6 +81,7 @@ class ToolRegistry {
   /// Registers a [ClientTool] and returns a new registry containing it.
   ///
   /// The tool is keyed by the tool definition's name.
+  @useResult
   ToolRegistry register(ClientTool tool) {
     return ToolRegistry._({..._tools, tool.definition.name: tool}, _aliases);
   }
@@ -89,6 +90,7 @@ class ToolRegistry {
   ///
   /// The alias is only used by [lookup] / [execute] / [contains]; it does
   /// not appear in [toolDefinitions].
+  @useResult
   ToolRegistry alias(String aliasName, String canonicalName) {
     return ToolRegistry._(_tools, {..._aliases, aliasName: canonicalName});
   }
@@ -98,6 +100,7 @@ class ToolRegistry {
   /// If [name] is an alias, only the alias is removed; the canonical
   /// tool remains. If [name] is a canonical name, the tool and any
   /// aliases pointing to it are removed.
+  @useResult
   ToolRegistry unregister(String name) {
     if (_aliases.containsKey(name)) {
       return ToolRegistry._(_tools, {..._aliases}..remove(name));


### PR DESCRIPTION
## Summary
- Adds `@useResult` annotation to `register()`, `alias()`, and `unregister()` on the immutable `ToolRegistry` class
- Prevents silent state loss when callers forget to capture the returned new instance

## Changes
- **`soliplex_agent/lib/src/tools/tool_registry.dart`**: Added `@useResult` from `package:meta` to the three builder methods

## Test plan
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart test` — 258 passed (3 pre-existing integration failures unrelated)
- [x] Verified all existing callers already capture return values (no new warnings)

Closes #168